### PR TITLE
build: Adjust for kernel mctp.h

### DIFF
--- a/src/mctp.h
+++ b/src/mctp.h
@@ -19,6 +19,7 @@
 #if HAVE_LINUX_MCTP_H
 #include <linux/mctp.h>
 #endif
+#include <linux/if_link.h>
 
 #ifndef AF_MCTP
 #define AF_MCTP 45
@@ -32,10 +33,6 @@
 #include <stdint.h>
 
 #ifndef MCTP_NET_ANY
-
-#ifndef MAX_ADDR_LEN
-#define MAX_ADDR_LEN 32
-#endif
 
 typedef uint8_t			mctp_eid_t;
 
@@ -53,6 +50,16 @@ struct sockaddr_mctp {
 	uint8_t			__smctp_pad1;
 };
 
+#define MCTP_NET_ANY 0
+#define MCTP_ADDR_ANY 0xff
+#define MCTP_TAG_OWNER 0x08
+
+#endif /* MCTP_NET_ANY */
+
+#ifndef MAX_ADDR_LEN
+#define MAX_ADDR_LEN 32
+#endif
+
 struct sockaddr_mctp_ext {
 	struct sockaddr_mctp	smctp_base;
 	int			smctp_ifindex;
@@ -60,12 +67,6 @@ struct sockaddr_mctp_ext {
 	uint8_t			__smctp_pad0[3];
 	unsigned char		smctp_haddr[MAX_ADDR_LEN];
 };
-
-#define MCTP_NET_ANY 0
-#define MCTP_ADDR_ANY 0xff
-#define MCTP_TAG_OWNER 0x08
-
-#endif /* MCTP_NET_ANY */
 
 #ifndef IFLA_MCTP_MAX
 


### PR DESCRIPTION
Starting 5.15 kernel has mctp.h as well and provides some of the
defintions, therefore move the ones we need to provide in this header
outside the conditional check so its always provided regardless of
header coming from kernel or not.

Include linux/if_link.h so it can pre-define IFLA_MCTP_UNSPEC and other
defines and there is a check for conditionally providing them here but
kernel does not have such a check, so if linux/if_link.h is included
after this header then we end up with duplicate defines

linux/if_link.h:1267:2: error: redefinition of enumerator 'IFLA_MCTP_UNSPEC'
        IFLA_MCTP_UNSPEC,
        ^
../git/src/mctp.h:74:2: note: previous definition is here
        IFLA_MCTP_UNSPEC,
        ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>