### PR TITLE
meson: Install all systemd units

### DIFF
--- a/conf/meson.build
+++ b/conf/meson.build
@@ -1,0 +1,18 @@
+systemd = dependency('systemd')
+
+if systemd.found()
+    servicedir = systemd.get_variable('systemdsystemunitdir')
+    unit_files = [
+        'mctp-local.target',
+        'mctp.target',
+        'mctpd.service',
+    ]
+
+    foreach unit : unit_files
+    configure_file(input: unit,
+                   output: unit,
+                   copy: true,
+                   install_dir: servicedir)
+    endforeach
+endif
+

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 #
 project(
     'mctp', 'c',
-    meson_version: '>= 0.47.0',
+    meson_version: '>= 0.58.0',
     version: 'v1.1',
     license: 'GPLv2',
     default_options: [
@@ -52,3 +52,5 @@ if libsystemd.found()
         install_dir: get_option('sbindir'),
     )
 endif
+
+subdir('conf')


### PR DESCRIPTION
Previously the systemd units were not installed and it depends on the bitbake recipe (in meta-openembedded) to install the service only.

Update the meson.build and install all the units. The bitbake recipe will need to be updated to add missing units to `SYSTEMD_SERVICE:${PN}`.