### PR TITLE
mctpd: Make timeout and bus owner configs configurable

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -3074,9 +3074,10 @@ static int setup_testing(ctx *ctx) {
 
 static void print_usage(ctx *ctx)
 {
-	fprintf(stderr, "mctpd [-v] [-N]\n");
+	fprintf(stderr, "mctpd [-v] [-N] [-t usecs]\n");
 	fprintf(stderr, "      -v verbose\n");
 	fprintf(stderr, "      -N testing mode. Not safe for production\n");
+	fprintf(stderr, "      -t timeout in usecs\n");
 }
 
 static int parse_args(ctx *ctx, int argc, char **argv)
@@ -3085,12 +3086,16 @@ static int parse_args(ctx *ctx, int argc, char **argv)
 		{ .name = "help", .has_arg = no_argument, .val = 'h' },
 		{ .name = "verbose", .has_arg = no_argument, .val = 'v' },
 		{ .name = "testing", .has_arg = no_argument, .val = 'N' },
+		{ .name = "timeout", .has_arg = required_argument, .val = 't' },
 		{ 0 },
 	};
 	int c;
 
+	// default values
+	ctx->mctp_timeout = 250000; // 250ms
+
 	for (;;) {
-		c = getopt_long(argc, argv, "+hvN", options, NULL);
+		c = getopt_long(argc, argv, "+hvNt:", options, NULL);
 		if (c == -1)
 			break;
 
@@ -3100,6 +3105,13 @@ static int parse_args(ctx *ctx, int argc, char **argv)
 			break;
 		case 'v':
 			ctx->verbose = true;
+			break;
+		case 't':
+			ctx->mctp_timeout = strtoull(optarg, NULL, 10);
+			if (ctx->mctp_timeout == 0) {
+				warnx("Timeout must be a non-zero u64");
+				return errno;
+			}
 			break;
 		case 'h':
 		default:
@@ -3138,7 +3150,6 @@ static int setup_config(ctx *ctx)
 {
 	int rc;
 	// TODO: this will go in a config file or arguments.
-	ctx->mctp_timeout = 250000; // 250ms
 	ctx->bus_owner = true;
 	rc = fill_uuid(ctx);
 	if (rc < 0)


### PR DESCRIPTION
Currently, the timeout and bus owner configs is statically defined inside `mctpd.c`. This PR makes those configs configurable:

- The timeout can be configured via a program argument, so that people can tweak it at runtime if necessary.
- ~~The bus owner config can be configured via `meson_options.txt`, because this seems to be a build time / one time decision~~. The bus owner config is changed to be configured via a program argument for easier use.