### PR TITLE
Add mctp test infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,17 @@ ninja -C obj
 cd obj
 pytest
 ```
+
+This depends on a few python packages, including the pytest binary. You can
+use a python `venv` to provide these:
+
+```sh
+python3 -m venv venv
+venv/bin/pip install -r tests/requirements.txt
+```
+
+Then run the tests using the new `venv`'s `pytest`:
+
+```sh
+../venv/bin/pytest
+```

--- a/README.md
+++ b/README.md
@@ -101,13 +101,19 @@ We have an initial test suite under tests/. To run:
 
 ```sh
 meson setup obj
-ninja -C obj
+ninja -C obj test
+```
+
+Alternatively, you can run `pytest` directly; this may be more useful
+during development:
+
+```sh
 cd obj
 pytest
 ```
 
-This depends on a few python packages, including the pytest binary. You can
-use a python `venv` to provide these:
+The test infrastructure depends on a few python packages, including the pytest
+binary. You can use a python `venv` to provide these:
 
 ```sh
 python3 -m venv venv
@@ -117,5 +123,6 @@ venv/bin/pip install -r tests/requirements.txt
 Then run the tests using the new `venv`'s `pytest`:
 
 ```sh
-../venv/bin/pytest
+PATH=$PWD/venv/bin/:$PATH meson setup obj
+ninja -C obj test
 ```

--- a/README.md
+++ b/README.md
@@ -93,3 +93,15 @@ where `mctpd` exposes three dbus interfaces for each:
 
  - `au.com.CodeConstruct.MCTP.EndPoint`: Additional control methods for the
    endpoint - for example, `Remove`
+
+Testing
+-------
+
+We have an initial test suite under tests/. To run:
+
+```sh
+meson setup obj
+ninja -C obj
+cd obj
+pytest
+```

--- a/meson.build
+++ b/meson.build
@@ -35,9 +35,10 @@ config_h = configure_file(
 
 util_sources = ['src/mctp-util.c']
 netlink_sources = ['src/mctp-netlink.c']
+ops_sources = ['src/mctp-ops.c']
 
 executable('mctp',
-    sources: ['src/mctp.c'] + netlink_sources + util_sources,
+    sources: ['src/mctp.c'] + netlink_sources + util_sources + ops_sources,
     install: true,
 )
 
@@ -53,7 +54,7 @@ if libsystemd.found()
     executable('mctpd',
         sources: [
             'src/mctpd.c',
-        ] + netlink_sources + util_sources,
+        ] + netlink_sources + util_sources + ops_sources,
         dependencies: libsystemd,
         install: true,
         install_dir: get_option('sbindir'),

--- a/meson.build
+++ b/meson.build
@@ -59,4 +59,23 @@ if libsystemd.found()
         install: true,
         install_dir: get_option('sbindir'),
     )
+
+    mctpd_test = executable('test-mctpd',
+        sources: [
+            'src/mctpd.c',
+            'tests/mctp-ops-test.c',
+        ] + netlink_sources + util_sources,
+        include_directories:  include_directories('src'),
+        dependencies: libsystemd,
+    )
 endif
+
+test_conf_data = configuration_data()
+test_conf_data.set('testpaths',
+  join_paths(meson.current_source_dir(), 'tests')
+)
+configure_file(
+    input: 'tests/pytest.ini.in',
+    output: 'pytest.ini',
+    configuration: test_conf_data,
+)

--- a/meson.build
+++ b/meson.build
@@ -79,3 +79,12 @@ configure_file(
     output: 'pytest.ini',
     configuration: test_conf_data,
 )
+
+pytest = find_program('pytest', required: false)
+
+if pytest.found()
+    test('test-mctpd', pytest,
+        args: '--tap',
+        protocol: 'tap',
+    )
+endif

--- a/src/mctp-ops.c
+++ b/src/mctp-ops.c
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * mctp-ops: Abstraction for socket operations for mctp & mctpd.
+ *
+ * Copyright (c) 2023 Code Construct
+ */
+
+#define _GNU_SOURCE
+
+#include <unistd.h>
+#include <linux/netlink.h>
+
+#include "mctp-ops.h"
+
+static int mctp_op_mctp_socket(void)
+{
+	return socket(AF_MCTP, SOCK_DGRAM, 0);
+}
+
+static int mctp_op_netlink_socket(void)
+{
+	return socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+}
+
+static int mctp_op_bind(int sd, struct sockaddr *addr, socklen_t addrlen)
+{
+	return bind(sd, addr, addrlen);
+}
+
+static int mctp_op_setsockopt(int sd, int level, int optname, void *optval,
+			       socklen_t optlen)
+{
+	return setsockopt(sd, level, optname, optval, optlen);
+}
+
+static ssize_t mctp_op_sendto(int sd, const void *buf, size_t len, int flags,
+			       const struct sockaddr *dest, socklen_t addrlen)
+{
+	return sendto(sd, buf, len, flags, dest, addrlen);
+}
+
+static ssize_t mctp_op_recvfrom(int sd, void *buf, size_t len, int flags,
+				 struct sockaddr *src, socklen_t *addrlen)
+{
+	return recvfrom(sd, buf, len, flags, src, addrlen);
+}
+
+static int mctp_op_close(int sd)
+{
+	return close(sd);
+}
+
+struct mctp_ops mctp_ops = {
+	.mctp = {
+		.socket = mctp_op_mctp_socket,
+		.setsockopt = mctp_op_setsockopt,
+		.bind = mctp_op_bind,
+		.sendto = mctp_op_sendto,
+		.recvfrom = mctp_op_recvfrom,
+		.close = mctp_op_close,
+	},
+	.nl = {
+		.socket = mctp_op_netlink_socket,
+		.setsockopt = mctp_op_setsockopt,
+		.bind = mctp_op_bind,
+		.sendto = mctp_op_sendto,
+		.recvfrom = mctp_op_recvfrom,
+		.close = mctp_op_close,
+	},
+};
+
+void mctp_ops_init(void) { }

--- a/src/mctp-ops.h
+++ b/src/mctp-ops.h
@@ -1,0 +1,33 @@
+
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * mctpd: bus owner for MCTP using Linux kernel
+ *
+ * Copyright (c) 2023 Code Construct
+ */
+#pragma once
+
+#include <sys/socket.h>
+
+#define _GNU_SOURCE
+
+struct socket_ops {
+	int (*socket)(void);
+	int (*setsockopt)(int sd, int level, int optname, void *optval,
+			  socklen_t optlen);
+	int (*bind)(int sd, struct sockaddr *addr, socklen_t addrlen);
+	ssize_t (*sendto)(int sd, const void *buf, size_t len, int flags,
+			  const struct sockaddr *dest, socklen_t addrlen);
+	ssize_t (*recvfrom)(int sd, void *buf, size_t len, int flags,
+			    struct sockaddr *src, socklen_t *addrlen);
+	int (*close)(int sd);
+};
+
+struct mctp_ops {
+	struct socket_ops mctp;
+	struct socket_ops nl;
+};
+
+extern struct mctp_ops mctp_ops;
+
+void mctp_ops_init(void);

--- a/src/mctp.c
+++ b/src/mctp.c
@@ -33,6 +33,7 @@
 #include "mctp.h"
 #include "mctp-util.h"
 #include "mctp-netlink.h"
+#include "mctp-ops.h"
 
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define min(a, b) ((a) < (b) ? (a) : (b))
@@ -768,6 +769,8 @@ static int cmd_addr_addremove(struct ctx *ctx,
 		warnx("invalid dev spec");
 		return -1;
 	}
+
+	mctp_ops_init();
 
 	eidstr = argv[1];
 	linkstr = argv[3];

--- a/src/mctp.c
+++ b/src/mctp.c
@@ -1309,6 +1309,7 @@ int main(int argc, char **argv)
 	if (!cmd)
 		errx(EXIT_FAILURE, "no such command '%s'", cmdname);
 
+	mctp_ops_init();
 	ctx->nl = mctp_nl_new(ctx->verbose);
 	if (!ctx->nl)
 		errx(EXIT_FAILURE, "Error creating netlink object");

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -720,6 +720,9 @@ static int cb_listen_control_msg(sd_event_source *s, int sd, uint32_t revents,
 	if (rc < 0)
 		goto out;
 
+	if (rc == 0)
+		errx(EXIT_FAILURE, "Control socket returned EOF");
+
 	if (addr.smctp_base.smctp_type != MCTP_CTRL_HDR_MSG_TYPE) {
 		warnx("BUG: Wrong message type for listen socket");
 		rc = -EINVAL;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,800 @@
+
+import array
+import trio
+import socket
+import struct
+import sys
+import os
+import uuid
+import errno
+from collections import namedtuple
+
+from pyroute2 import netlink
+from pyroute2.netlink import rtnl
+
+import pytest
+import asyncdbus
+
+AF_NETLINK = 16
+AF_MCTP = 45
+ARPHRD_MCTP = 290
+IFLA_MCTP_NET = 1
+
+MAX_SOCKADDR_SIZE = 56
+
+# can be serialised into a NLMSG_ERROR
+class NetlinkError(Exception):
+    def __init__(self, errno, msg = None):
+        self.errno = errno
+        self.msg = msg
+
+    def to_nlmsg(self, seq = 0):
+        resp = netlink.nlmsgerr()
+        resp['header']['sequence_number'] = seq
+        resp['header']['pid'] = 0
+        resp['header']['type'] = netlink.NLMSG_ERROR
+        resp['error'] = -self.errno
+        if self.msg:
+            resp['attrs'] = [['NLMSGERR_ATTR_MSG', self.msg]]
+        return resp
+
+class System:
+    class Interface:
+        def __init__(self, name, ifindex, net, lladdr, mtu, up = False):
+            self.name = name
+            self.ifindex = ifindex
+            self.net = net
+            self.lladdr = lladdr,
+            self.mtu = mtu
+            self.up = up
+
+        def __str__(self):
+            lladdrstr = ':'.join('%02x' % ord(b) for b in self.lladdr)
+            return f"{self.name}: net {self.net} lladdr {lladdrstr}"
+
+    class Address:
+        def __init__(self, iface, eid):
+            self.iface = iface
+            self.eid = eid
+
+        def __str__(self):
+            return f"{self.eid} ({self.iface.name})"
+
+    class Neighbour:
+        def __init__(self, iface, lladdr, eid):
+            self.iface = iface
+            self.lladdr = lladdr
+            self.eid = eid
+
+        def __str__(self):
+            lladdrstr = ':'.join('%02x' % b for b in self.lladdr)
+            return f"{self.eid} -> {lladdrstr} {self.iface.name}"
+
+    class Route:
+        def __init__(self, iface, start_eid, extent_eid, mtu = 0):
+            self.iface = iface
+            self.start_eid = start_eid
+            self.end_eid = start_eid + extent_eid
+            self.mtu = mtu
+
+        def __str__(self):
+            return (f"{self.start_eid}-{self.end_eid} -> " +
+                    f"{self.iface.name} mtu {self.mtu}")
+
+    def __init__(self):
+        self.interfaces = []
+        self.addresses = []
+        self.neighbours = []
+        self.routes = []
+
+    def add_route(self, route):
+        self.routes.append(route)
+
+    def add_interface(self, iface):
+        self.interfaces.append(iface)
+
+    def add_address(self, address):
+        self.addresses.append(address)
+
+    def add_neighbour(self, neigh):
+        if self.lookup_neighbour(neigh.iface, neigh.eid):
+            raise NetlinkError(errno.EEXIST)
+        self.neighbours.append(neigh)
+
+    def find_interface_by_ifindex(self, ifindex):
+        for i in self.interfaces:
+            if i.ifindex == ifindex:
+                return i
+        return None
+
+    def find_interface_by_name(self, name):
+        for i in self.interfaces:
+            if i.name == name:
+                return i
+        return None
+
+    def lookup_route(self, net, eid):
+        for rt in self.routes:
+            eid_range = range(rt.start_eid, rt.end_eid + 1)
+            if net in (0, rt.iface.net) and eid in eid_range:
+                return rt
+        return None
+
+    def lookup_neighbour(self, iface, eid):
+        for neighbour in self.neighbours:
+            if neighbour.iface == iface and neighbour.eid == eid:
+                return neighbour
+        return None
+
+    def find_endpoint(self, addr):
+        iface = None
+        lladdr = None
+        if addr.is_ext:
+            iface = self.find_interface_by_ifindex(addr.ifindex)
+            lladdr = addr.lladdr
+        else:
+            route = self.lookup_route(addr.net, addr.eid)
+            if route == None:
+                return None
+            iface = route.iface
+
+            neigh = self.lookup_neighbour(route.iface, addr.eid)
+            lladdr = neigh.lladdr
+
+        if iface is None or lladdr is None:
+            return None
+
+        return iface, lladdr
+
+    def dump(self):
+        print("system:")
+        if self.interfaces:
+            print(" interfaces:")
+            for i in self.interfaces:
+                print(f"  {i}")
+        if self.addresses:
+            print(" addresses:")
+            for a in self.addresses:
+                print(f"  {a}")
+        if self.routes:
+            print(" routes:")
+            for r in self.routes:
+                print(f"  {r}")
+        if self.neighbours:
+            print(" neighbours:")
+            for n in self.neighbours:
+                print(f"  {n}")
+
+class Endpoint:
+    def __init__(self, iface, lladdr, ep_uuid = None, eid = 0, types = None):
+        self.iface = iface
+        self.lladdr = lladdr
+        self.uuid = ep_uuid or uuid.uuid1()
+        self.eid = eid
+        self.types = types or [0]
+
+    def __str__(self):
+        return f"uuid {self.uuid} lladdr {self.lladdr}, eid {self.eid}"
+
+class Network:
+    def __init__(self):
+        self.endpoints = []
+
+    def add_endpoint(self, endpoint):
+        self.endpoints.append(endpoint)
+
+    def lookup_endpoint(self, iface, lladdr):
+        for ep in self.endpoints:
+            if ep.iface == iface and ep.lladdr == lladdr:
+                return ep
+        return None
+
+# MCTP-capable pyroute2 objects
+class ifinfmsg_mctp(rtnl.ifinfmsg.ifinfmsg):
+    class af_spec(netlink.nla):
+        prefix = 'IFLA_'
+        nla_map = (
+            (AF_MCTP, 'AF_MCTP', 'af_spec_mctp'),
+        )
+
+        class af_spec_mctp(netlink.nla):
+            prefix = 'IFLA_MCTP_'
+            nla_map = (
+                ('IFLA_MCTP_UNSPEC', 'none'),
+                ('IFLA_MCTP_NET', 'uint32'),
+            )
+
+    class l2addr(netlink.nla_base):
+        fields = [('value', 'c')]
+
+class ifaddrmsg_mctp(rtnl.ifaddrmsg.ifaddrmsg):
+    nla_map = (
+        ('IFA_UNSPEC', 'hex'),
+        ('IFA_ADDRESS', 'uint8'),
+        ('IFA_LOCAL', 'uint8'),
+        ('IFA_LABEL', 'asciiz'),
+        ('IFA_BROADCAST', 'uint8'),
+        ('IFA_ANYCAST', 'uint8'),
+        ('IFA_CACHEINFO', 'cacheinfo'),
+        ('IFA_MULTICAST', 'uint8'),
+        ('IFA_FLAGS', 'uint32'),
+    )
+
+class ndmsg_mctp(rtnl.ndmsg.ndmsg):
+    nla_map = (
+        ('NDA_UNSPEC', 'none'),
+        ('NDA_DST', 'uint8'),
+        ('NDA_LLADDR', 'lladdr'),
+        ('NDA_CACHEINFO', 'cacheinfo'),
+        ('NDA_PROBES', 'uint32'),
+        ('NDA_VLAN', 'uint16'),
+        ('NDA_PORT', 'be16'),
+        ('NDA_VNI', 'uint32'),
+        ('NDA_IFINDEX', 'uint32'),
+        ('NDA_MASTER', 'uint32'),
+    )
+
+    class lladdr(netlink.nla_base):
+        fields = [('value', 'c')]
+
+class rtmsg_mctp(rtnl.rtmsg.rtmsg):
+    nla_map = (
+        ('RTA_UNSPEC', 'none'),
+        ('RTA_DST', 'uint8'),
+        ('RTA_SRC', 'uint8'),
+        ('RTA_IIF', 'uint32'),
+        ('RTA_OIF', 'uint32'),
+        ('RTA_GATEWAY', 'uint8'),
+        ('RTA_PRIORITY', 'uint32'),
+        ('RTA_PREFSRC', 'uint8'),
+        ('RTA_METRICS', 'metrics'),
+        ('RTA_MULTIPATH', '*get_nh'),
+        ('RTA_PROTOINFO', 'uint32'),
+        ('RTA_FLOW', 'uint32'),
+        ('RTA_CACHEINFO', 'cacheinfo'),
+        ('RTA_SESSION', 'hex'),
+        ('RTA_MP_ALGO', 'hex'),
+        ('RTA_TABLE', 'uint32'),
+        ('RTA_MARK', 'uint32'),
+        ('RTA_MFC_STATS', 'rta_mfc_stats'),
+        ('RTA_VIA', 'rtvia'),
+        ('RTA_NEWDST', 'uint8'),
+        ('RTA_PREF', 'uint8'),
+        ('RTA_ENCAP_TYPE', 'uint16'),
+        ('RTA_ENCAP', 'encap_info'),
+        ('RTA_EXPIRES', 'hex'),
+    )
+
+class BaseSocket:
+    msg_fmt = "@I"
+
+    def __init__(self, sock):
+        self.sock = sock
+
+    async def run(self):
+        while True:
+            data = await self.sock.recv(1024)
+            if len(data) == 0:
+                break
+
+            await self.recv_msg(data)
+
+    async def recv_msg(self, data):
+        (typ,) = struct.unpack("@I", data[0:4])
+        data = data[4:]
+        if typ == 1:
+            # send op
+            addr = data[:MAX_SOCKADDR_SIZE]
+            addrlen = int.from_bytes(
+                    data[MAX_SOCKADDR_SIZE:MAX_SOCKADDR_SIZE+4],
+                    byteorder = sys.byteorder
+                )
+            data = data[MAX_SOCKADDR_SIZE+4:]
+            addr = addr[:addrlen]
+            await self.handle_send(addr, data)
+        elif typ == 2:
+            # setsockopt op
+            level, optname, optval = data[0:4], data[4:8], data[20:]
+            level = int.from_bytes(level, byteorder = sys.byteorder)
+            optname = int.from_bytes(optname, byteorder = sys.byteorder)
+            await self.handle_setsockopt(level, optname, optval)
+        else:
+            print(f"unknown message type {typ}")
+
+    async def send(self, addr, data):
+        addrlen = len(addr)
+        assert addrlen <= MAX_SOCKADDR_SIZE
+        addr += b'\0' * (MAX_SOCKADDR_SIZE - addrlen)
+        buf = struct.pack("@I", 0) + addr + struct.pack("@I", addrlen) + data
+        await self.sock.send(buf)
+
+class MCTPSockAddr:
+    base_addr_fmt = "@HHiBBBB"
+    ext_addr_fmt = "@iB3c" # just the header here, we append the lladdr data
+
+    @classmethod
+    def parse(cls, data, ext):
+        addrlen = len(data)
+        baselen = struct.calcsize(cls.base_addr_fmt)
+        extlen = struct.calcsize(cls.ext_addr_fmt)
+        assert addrlen >= baselen
+        base = data[:baselen]
+
+        _, _, net, eid, type, tag, _ = struct.unpack(cls.base_addr_fmt, base)
+        a = cls(net, eid, type, tag)
+
+        if ext and addrlen >= extlen + baselen:
+            ext = data[baselen:baselen + extlen]
+            parts = struct.unpack(cls.ext_addr_fmt, ext)
+            lladdr = data[baselen + extlen: baselen + extlen + parts[1]]
+            a.set_ext(parts[0], lladdr)
+
+        return a
+
+    @classmethod
+    def for_ep_resp(cls, ep, req_addr, ext):
+        a = cls(ep.iface.net, ep.eid, req_addr.type, req_addr.tag ^ 0x80)
+        if ext:
+            a.set_ext(ep.iface.ifindex, ep.lladdr)
+        return a
+
+    def __init__(self, net, eid, type, tag):
+        self.net = net
+        self.eid = eid
+        self.type = type
+        self.tag = tag
+        self.is_ext = False
+
+    def set_ext(self, ifindex, lladdr):
+        self.is_ext = True
+        self.ifindex = ifindex
+        self.lladdr = lladdr
+
+
+    def to_buf(self):
+        data = struct.pack(self.base_addr_fmt,
+                AF_MCTP, 0, self.net, self.eid, self.type, self.tag, 0)
+        if self.is_ext:
+            # pad to MAX_ADDR_LEN
+            lladdr_data = self.lladdr + bytes([0] * (32 - len(self.lladdr)))
+            data += struct.pack(self.ext_addr_fmt,
+                        self.ifindex, len(self.lladdr),
+                        b'\0', b'\0', b'\0')
+            data += lladdr_data
+        return data
+
+    def __str__(self):
+        u = f"net {self.net} eid {self.eid} type {self.type} tag {self.tag}"
+        if self.is_ext:
+            u += f" ext {{ ifindex {self.ifindex} lladdr {self.lladdr} }}"
+        return u
+
+
+class MCTPSocket(BaseSocket):
+    base_addr_fmt = "@HHIIBBBB"
+    ext_addr_fmt = "@HHIIBBBBIBB32s"
+
+    def __init__(self, sock, system, network):
+        super().__init__(sock)
+        self.addr_ext = False
+        self.system = system
+        self.network = network
+
+    async def handle_send(self, addr, data):
+        a = MCTPSockAddr.parse(addr, self.addr_ext)
+        phys = self.system.find_endpoint(a)
+        if phys is None:
+            return
+
+        ep = self.network.lookup_endpoint(*phys)
+        if ep is None:
+            return
+
+        if a.type == 0:
+            await self._handle_mctp_control(ep, a, data)
+        else:
+            print(f"unknown MCTP message type {a.type}")
+
+    async def _handle_mctp_control(self, ep, addr, data):
+        flags, opcode = data[0:2]
+        raddr = MCTPSockAddr.for_ep_resp(ep, addr, self.addr_ext)
+        hdr = [0x00, opcode]
+        if opcode == 1:
+            # Set Endpoint ID
+            (op, eid) = data[2:]
+            ep.eid = eid
+            data = bytes(hdr + [0x00, 0x00, ep.eid, 0x00])
+            await self.send(raddr, data)
+
+        elif opcode == 2:
+            # Get Endpoint ID
+            data = bytes(hdr + [0x00, ep.eid, 0x00, 0x00])
+            await self.send(raddr, data)
+
+        elif opcode == 3:
+            # Get Endpoint UUID
+            data = bytes(hdr + [0x00]) + ep.uuid.bytes
+            await self.send(raddr, data)
+
+        elif opcode == 5:
+            # Get Message Type Support
+            types = ep.types
+            data = bytes(hdr + [0x00, len(types)] + types)
+            await self.send(raddr, data)
+
+        else:
+            await self.send(raddr, bytes(hdr + [0x05])) # unsupported command
+
+
+    async def handle_setsockopt(self, level, optname, optval):
+        if level == 285 and optname == 1:
+            val = int.from_bytes(optval, byteorder = sys.byteorder)
+            self.addr_ext = bool(val)
+
+    async def send(self, addr, data):
+        addrbuf = addr.to_buf()
+        addrlen = len(addrbuf)
+        assert addrlen <= MAX_SOCKADDR_SIZE
+        addrbuf += b'\0' * (MAX_SOCKADDR_SIZE - addrlen)
+        buf = struct.pack("@I", 0) + addrbuf + struct.pack("@I", addrlen) + data
+        await self.sock.send(buf)
+
+class NLSocket(BaseSocket):
+    addr_fmt = "@HHII"
+
+    def __init__(self, sock, system):
+        super().__init__(sock)
+        self.addr_ext = False
+        self.system = system
+
+    def _create_resp(self, cls, req, type, flags):
+        resp = cls()
+        resp['header']['sequence_number'] = req['header']['sequence_number']
+        resp['header']['pid'] = 0
+        resp['header']['type'] = type
+        resp['header']['flags'] = flags
+        return resp
+
+    def _append_nlmsg_done(self, buf, req):
+        resp = netlink.nlmsg()
+        resp['header']['sequence_number'] = req['header']['sequence_number']
+        resp['header']['pid'] = 0
+        resp['header']['type'] = netlink.NLMSG_DONE
+        resp.encode()
+        buf.extend(resp.data)
+
+    async def _nlmsg_ack(self, req):
+        resp = netlink.nlmsgerr()
+        resp['header']['sequence_number'] = req['header']['sequence_number']
+        resp['header']['pid'] = 0
+        resp['header']['type'] = netlink.NLMSG_ERROR
+        resp['error'] = 0
+        resp.encode()
+        await self._send_resp(resp.data)
+
+    async def handle_send(self, addr, data):
+        addr = addr[:struct.calcsize(self.addr_fmt)]
+        addr = struct.unpack(self.addr_fmt, addr)
+        msg = netlink.nlmsg(data)
+        msg.decode()
+        header = msg['header']
+        typ = header['type']
+
+        if not header['flags'] & netlink.NLM_F_REQUEST:
+            print("error: not a request?");
+            return
+
+        if typ == rtnl.RTM_GETLINK:
+            await self._handle_getlink(msg)
+        elif typ == rtnl.RTM_GETADDR:
+            await self._handle_getaddr(msg)
+
+        elif typ == rtnl.RTM_GETROUTE:
+            await self._handle_getroute(msg)
+        elif typ == rtnl.RTM_NEWROUTE:
+            await self._handle_newroute(msg)
+
+        elif typ == rtnl.RTM_GETNEIGH:
+            await self._handle_getneigh(msg)
+        elif typ == rtnl.RTM_NEWNEIGH:
+            await self._handle_newneigh(msg)
+
+        else:
+            print(f"unknown NL type {typ:x}")
+
+    async def handle_setsockopt(self, level, optname, optval):
+        pass
+
+    async def _send_resp(self, buf):
+        addr = struct.pack(self.addr_fmt, AF_NETLINK, 0, 0, 0)
+        await self.send(addr, buf)
+
+    async def _handle_getlink(self, msg):
+        dump = bool(msg['header']['flags'] & netlink.NLM_F_DUMP)
+        assert dump
+
+        buf = bytearray()
+        flags = netlink.NLM_F_MULTI if dump else 0
+
+        ifaces = []
+        if dump:
+            ifaces = self.system.interfaces
+
+        for iface in ifaces:
+            resp = self._create_resp(ifinfmsg_mctp, msg, rtnl.RTM_NEWLINK, flags)
+            resp['index'] = iface.ifindex
+            resp['family'] = 0
+            resp['type'] = ARPHRD_MCTP
+            resp['flags'] = (
+                rtnl.ifinfmsg.IFF_RUNNING |
+                (rtnl.ifinfmsg.IFF_UP | rtnl.ifinfmsg.IFF_LOWER_UP
+                    if iface.up else 0)
+            )
+
+            resp['attrs'] = [
+                ['IFLA_IFNAME', iface.name],
+                ['IFLA_ADDRESS', iface.lladdr],
+                ['IFLA_MTU', iface.mtu],
+                ['IFLA_AF_SPEC', {
+                    'attrs': [['AF_MCTP', {
+                        'attrs': [['IFLA_MCTP_NET', iface.net]],
+                    }]],
+                }],
+            ]
+
+            resp.encode()
+            buf.extend(resp.data)
+
+        self._append_nlmsg_done(buf, msg)
+        await self._send_resp(buf)
+
+    async def _handle_getaddr(self, msg):
+        dump = bool(msg['header']['flags'] & netlink.NLM_F_DUMP)
+        assert dump
+
+        buf = bytearray()
+        flags = netlink.NLM_F_MULTI if dump else 0
+
+        addrs = []
+        if dump:
+            addrs = self.system.addresses
+
+        for addr in addrs:
+            resp = self._create_resp(ifaddrmsg_mctp, msg,
+                    rtnl.RTM_NEWADDR, flags)
+            resp['index'] = addr.iface.ifindex
+            resp['family'] = AF_MCTP
+            resp['prefixlen'] = 0
+            resp['flags'] = 0
+            resp['attrs'] = [
+                ['IFA_LOCAL', addr.eid],
+            ]
+            resp.encode()
+            buf.extend(resp.data)
+
+        self._append_nlmsg_done(buf, msg)
+
+        await self._send_resp(buf)
+
+    async def _handle_getneigh(self, msg):
+        dump = bool(msg['header']['flags'] & netlink.NLM_F_DUMP)
+        assert dump
+
+        buf = bytearray()
+        flags = netlink.NLM_F_MULTI if dump else 0
+
+        if dump:
+            neighbours = self.system.neighbours
+
+        for n in neighbours:
+            resp = self._create_resp(ndmsg_mctp, msg, rtnl.RTM_NEWNEIGH, flags)
+            resp['ifindex'] = n.iface.ifindex
+            resp['attrs'] = [
+                ['NDA_DST', n.eid],
+                ['NDA_LLADDR', n.lladdr],
+            ]
+            resp.encode()
+            buf.extend(resp.data)
+
+        self._append_nlmsg_done(buf, msg)
+
+        await self._send_resp(buf)
+
+    async def _handle_newneigh(self, msg):
+        # reparse as ndmsg
+        msg = ndmsg_mctp(msg.data)
+        msg.decode()
+
+        ifindex = msg['ifindex']
+        dst = msg.get_attr('NDA_DST')
+        lladdr = msg.get_attr('NDA_LLADDR')
+
+        iface = self.system.find_interface_by_ifindex(ifindex)
+        neighbour = System.Neighbour(iface, lladdr, dst)
+        try:
+            self.system.add_neighbour(neighbour)
+        except NetlinkError as nle:
+            msg = nle.to_nlmsg()
+            msg.encode()
+            await self._send_resp(msg.data)
+            return
+
+        if msg['header']['flags'] & netlink.NLM_F_ACK:
+            await self._nlmsg_ack(msg)
+
+    async def _handle_getroute(self, msg):
+        dump = bool(msg['header']['flags'] & netlink.NLM_F_DUMP)
+        assert dump
+
+        buf = bytearray()
+        flags = netlink.NLM_F_MULTI if dump else 0
+
+        if dump:
+            routes = self.system.routes
+
+        for route in routes:
+            resp = self._create_resp(rtmsg_mctp, msg, rtnl.RTM_NEWROUTE, flags)
+            resp['family'] = AF_MCTP
+            resp['dst_len'] = route.end_eid - route.start_eid
+            resp['src_len'] = 0
+            resp['attrs'] = [
+                ['RTA_DST', route.start_eid],
+                ['RTA_OIF', route.iface.ifindex],
+                ['RTA_METRICS', {
+                    'attrs': [['RTAX_MTU', route.mtu]],
+                }],
+            ]
+            resp.encode()
+            buf.extend(resp.data)
+
+        self._append_nlmsg_done(buf, msg)
+
+        await self._send_resp(buf)
+
+    async def _handle_newroute(self, msg):
+        msg = rtmsg_mctp(msg.data)
+        msg.decode()
+
+        ifindex = msg.get_attr('RTA_OIF')
+        start_eid = msg.get_attr('RTA_DST')
+        extent_eid = msg['dst_len']
+        # todo: RTAX metrics
+        mtu = 0
+
+        iface = self.system.find_interface_by_ifindex(ifindex)
+        route = System.Route(iface, start_eid, extent_eid)
+        self.system.add_route(route)
+
+        if msg['header']['flags'] & netlink.NLM_F_ACK:
+            await self._nlmsg_ack(msg)
+
+
+async def send_fd(sock, fd):
+    fdarray = array.array("i", [fd])
+    await sock.sendmsg([b'x'], [
+            (socket.SOL_SOCKET, socket.SCM_RIGHTS, fdarray),
+        ]
+    )
+
+
+class MctpdWrapper:
+    def __init__(self, bus, sysnet):
+        self.bus = bus
+        self.system = sysnet.system
+        self.network = sysnet.network
+        (self.sock_local, self.sock_remote) = self.socketpair()
+
+    def socketpair(self):
+        return trio.socket.socketpair(
+                trio.socket.AF_UNIX,
+                trio.socket.SOCK_SEQPACKET
+            )
+
+    async def handle_control(self, nursery):
+        while True:
+            data = await self.sock_local.recv(1024)
+            if len(data) == 0:
+                break
+            op = data[0]
+            if op == 0x00:
+                # init
+                await self.sock_local.send(b'a')
+
+            elif op == 0x01:
+                # MCTP socket()
+                (local, remote) = self.socketpair()
+                nl = MCTPSocket(local, self.system, self.network)
+                await send_fd(self.sock_local, remote.fileno())
+                remote.close()
+                nursery.start_soon(nl.run)
+
+            elif op == 0x02:
+                # NL socket()
+                (local, remote) = self.socketpair()
+                nl = NLSocket(local, self.system)
+                await send_fd(self.sock_local, remote.fileno())
+                remote.close()
+                nursery.start_soon(nl.run)
+
+            else:
+                print(f"unknown op {op}")
+
+    async def start_mctpd(self, nursery):
+        nursery.start_soon(self.handle_control, nursery)
+        self.proc = await nursery.start(self.mctpd_proc, nursery)
+
+    def stop_mctpd(self):
+        if self.proc:
+            self.proc.terminate()
+
+    async def mctpd_proc(self, nursery, task_status = trio.TASK_STATUS_IGNORED):
+        # We want to start the mctpd process, but not return before it's
+        # ready to interact with our test via dbus.
+        #
+        # So, we spawn the process here asynchronously, then monitor dbus for
+        # the Name Owner Changed signal that indicates that it has registered
+        # itself.
+        busobj = await self.bus.get_proxy_object(
+                'org.freedesktop.DBus',
+                '/org/freedesktop/DBus'
+            )
+        interface = await busobj.get_interface('org.freedesktop.DBus')
+
+        s = trio.Semaphore(initial_value = 0)
+        def name_owner_changed(name, new_owner, old_owner):
+            if name == 'xyz.openbmc_project.MCTP':
+                s.release()
+
+        await interface.on_name_owner_changed(name_owner_changed)
+
+        # start mctpd, passing our control socket
+        env = os.environ.copy()
+        env['MCTP_TEST_SOCK'] = str(self.sock_remote.fileno())
+        proc = await trio.lowlevel.open_process(
+                ['./test-mctpd', '-v'], # todo: flexible paths
+                pass_fds = (1, 2, self.sock_remote.fileno()),
+                env = env,
+            )
+        self.sock_remote.close()
+
+        # wait for name to appear, cancel NameOwnerChanged listener
+        await s.acquire()
+        await interface.off_name_owner_changed(name_owner_changed)
+
+        # The proc argument here will be passed as the return value for
+        # nursery.start. The caller will want this to terminate the
+        # process after the test has run.
+        task_status.started(proc)
+
+        await proc.wait()
+
+Sysnet = namedtuple('SysNet', ['system', 'network'])
+
+@pytest.fixture
+async def sysnet():
+    """Simple system & network.
+
+    Contains one interface (lladdr 0x10, local EID 8), and one endpoint (lladdr
+    0x1d), that reports support for MCTP control and PLDM.
+    """
+    system = System()
+    iface = System.Interface('mctp0', 1, 1, bytes([0x10]), 68, True)
+    system.add_interface(iface)
+    system.add_address(System.Address(iface, 8))
+
+    network = Network()
+    network.add_endpoint(Endpoint(iface, bytes([0x1d]), types = [0, 1]))
+
+    return Sysnet(system, network)
+
+@pytest.fixture
+async def dbus():
+    async with asyncdbus.MessageBus().connect() as bus:
+        yield bus
+
+@pytest.fixture
+async def mctpd(nursery, dbus, sysnet):
+    m = MctpdWrapper(dbus, sysnet)
+    await m.start_mctpd(nursery)
+    yield m
+    m.stop_mctpd()

--- a/tests/mctp-ops-test.c
+++ b/tests/mctp-ops-test.c
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * mctp-ops-test: Test implementations for mctp socket ops
+ *
+ * Copyright (c) 2023 Code Construct
+ */
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <linux/netlink.h>
+
+#include "mctp-ops.h"
+#include "test-proto.h"
+
+static int control_sd;
+
+static int mctp_op_socket(int type)
+{
+	union {
+		struct cmsghdr hdr;
+		unsigned char buf[CMSG_SPACE(sizeof(int))];
+	} msg;
+	struct cmsghdr *cmsg;
+	struct control_msg_req req;
+	struct control_msg_rsp rsp;
+	struct msghdr hdr = { 0 };
+	struct iovec iov;
+	int rc, var, sd;
+
+	if (type == AF_MCTP)
+		req.type = CONTROL_OP_SOCKET_MCTP;
+	else if (type == AF_NETLINK)
+		req.type = CONTROL_OP_SOCKET_NL;
+	else
+		errx(EXIT_FAILURE, "invalid socket type?");
+
+	rc = send(control_sd, &req, sizeof(req), 0);
+	if (rc < 0)
+		err(EXIT_FAILURE, "control send error");
+
+	iov.iov_base = &rsp;
+	iov.iov_len = sizeof(rsp);
+	hdr.msg_iov = &iov;
+	hdr.msg_iovlen = 1;
+	hdr.msg_control = &msg;
+	hdr.msg_controllen = sizeof(msg);
+	rc = recvmsg(control_sd, &hdr, 0);
+
+	cmsg = CMSG_FIRSTHDR(&hdr);
+	if (!cmsg || cmsg->cmsg_len != CMSG_LEN(sizeof(int))
+	    || cmsg->cmsg_level != SOL_SOCKET
+	    || cmsg->cmsg_type != SCM_RIGHTS)
+	{
+		errx(EXIT_FAILURE, "invalid control response");
+	}
+
+	memcpy(&sd, CMSG_DATA(cmsg), sizeof(int));
+	var = 0;
+	ioctl(sd, FIONBIO, &var);
+
+	return sd;
+}
+
+static int mctp_op_mctp_socket(void)
+{
+	return mctp_op_socket(AF_MCTP);
+}
+
+static int mctp_op_netlink_socket(void)
+{
+	return mctp_op_socket(AF_NETLINK);
+}
+
+static int mctp_op_bind(int sd, struct sockaddr *addr, socklen_t addrlen)
+{
+	return 0;
+}
+
+static int mctp_op_setsockopt(int sd, int level, int optname, void *optval,
+			       socklen_t optlen)
+{
+	struct msghdr msg = { 0 };
+	struct sock_msg sock_msg;
+	struct iovec iov[2];
+	ssize_t rc;
+
+	sock_msg.type = SOCK_SETSOCKOPT;
+	sock_msg.setsockopt.level = level;
+	sock_msg.setsockopt.optname = optname;
+
+	iov[0].iov_base = &sock_msg;
+	iov[0].iov_len = sizeof(sock_msg);
+	iov[1].iov_base = optval;
+	iov[1].iov_len = optlen;
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 2;
+
+	rc = sendmsg(sd, &msg, 0);
+	if (rc < 0)
+		return rc;
+
+	if (rc < (int)sizeof(sock_msg)) {
+		errno = EPROTO;
+		return -1;
+	}
+
+	/* todo: return code */
+	return 0;
+}
+
+static ssize_t mctp_op_sendto(int sd, const void *buf, size_t len, int flags,
+			       const struct sockaddr *dest, socklen_t addrlen)
+{
+	struct msghdr msg = { 0 };
+	struct sock_msg sock_msg;
+	struct iovec iov[2];
+	ssize_t rc;
+
+	sock_msg.type = SOCK_SEND;
+	sock_msg.send.addrlen = addrlen;
+	memcpy(&sock_msg.send.addr.buf, dest, addrlen);
+
+	iov[0].iov_base = &sock_msg;
+	iov[0].iov_len = sizeof(sock_msg);
+	iov[1].iov_base = (void *)buf;
+	iov[1].iov_len = len;
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 2;
+
+	rc = sendmsg(sd, &msg, 0);
+	if (rc < 0)
+		return rc;
+
+	if (rc < (int)sizeof(sock_msg)) {
+		errno = EPROTO;
+		return -1;
+	}
+
+	return rc - sizeof(sock_msg);
+}
+
+static ssize_t mctp_op_recvfrom(int sd, void *buf, size_t len, int flags,
+				 struct sockaddr *src, socklen_t *addrlenp)
+{
+	struct msghdr msg = { 0 };
+	struct sock_msg sock_msg;
+	struct iovec iov[2];
+	ssize_t rc;
+
+	iov[0].iov_base = &sock_msg;
+	iov[0].iov_len = sizeof(sock_msg);
+	iov[1].iov_base = (void *)buf;
+	iov[1].iov_len = len;
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 2;
+
+	rc = recvmsg(sd, &msg, flags);
+	if (rc <= 0)
+		return rc;
+
+	if (rc < (ssize_t)sizeof(sock_msg))
+		errx(EXIT_FAILURE, "ops protocol error");
+
+	if (sock_msg.type != SOCK_RECV)
+		errx(EXIT_FAILURE, "Unexpected message type %d?",
+		     sock_msg.type);
+
+	if (src)
+		memcpy(src, &sock_msg.recv.addr.buf, sock_msg.recv.addrlen);
+	if (addrlenp)
+		*addrlenp = sock_msg.recv.addrlen;
+
+	return rc - sizeof(sock_msg);
+}
+
+static int mctp_op_close(int sd)
+{
+	return close(sd);
+}
+
+struct mctp_ops mctp_ops = {
+	.mctp = {
+		.socket = mctp_op_mctp_socket,
+		.setsockopt = mctp_op_setsockopt,
+		.bind = mctp_op_bind,
+		.sendto = mctp_op_sendto,
+		.recvfrom = mctp_op_recvfrom,
+		.close = mctp_op_close,
+	},
+	.nl = {
+		.socket = mctp_op_netlink_socket,
+		.setsockopt = mctp_op_setsockopt,
+		.bind = mctp_op_bind,
+		.sendto = mctp_op_sendto,
+		.recvfrom = mctp_op_recvfrom,
+		.close = mctp_op_close,
+	},
+};
+
+void mctp_ops_init(void)
+{
+	struct control_msg_req req;
+	struct control_msg_rsp rsp;
+	const char *sockstr;
+	ssize_t len;
+	int var, sd;
+
+	sockstr = getenv("MCTP_TEST_SOCK");
+	if (!sockstr || !strlen(sockstr))
+		errx(EXIT_FAILURE, "No MCTP_TEST_SOCK fd provided");
+
+	sd = atoi(sockstr);
+	var = 0;
+	ioctl(sd, FIONBIO, &var);
+
+	req.type = CONTROL_OP_INIT;
+	len = send(sd, &req, sizeof(req), 0);
+	if (len != sizeof(req))
+		err(EXIT_FAILURE, "control init failed");
+
+	len = recv(sd, &rsp, sizeof(rsp), 0);
+	control_sd = sd;
+}
+

--- a/tests/mctp_test_utils.py
+++ b/tests/mctp_test_utils.py
@@ -1,0 +1,7 @@
+
+async def mctpd_mctp_obj(dbus):
+    obj = await dbus.get_proxy_object(
+            'xyz.openbmc_project.MCTP',
+            '/xyz/openbmc_project/mctp'
+        )
+    return await obj.get_interface('au.com.CodeConstruct.MCTP')

--- a/tests/pytest.ini.in
+++ b/tests/pytest.ini.in
@@ -1,0 +1,3 @@
+[pytest]
+trio_mode = true
+testpaths = @testpaths@

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,5 @@
+asyncdbus==0.6.1
+pyroute2==0.7.10
+pytest==7.4.3
+pytest-trio==0.8.0
+trio==0.23.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ pyroute2==0.7.10
 pytest==7.4.3
 pytest-trio==0.8.0
 trio==0.23.2
+pytest-tap==3.4

--- a/tests/test-proto.h
+++ b/tests/test-proto.h
@@ -1,0 +1,53 @@
+
+#include <stdint.h>
+
+#include <linux/mctp.h>
+#include <linux/netlink.h>
+
+enum {
+	CONTROL_OP_INIT,
+	CONTROL_OP_SOCKET_MCTP,
+	CONTROL_OP_SOCKET_NL,
+};
+
+struct control_msg_req {
+	uint8_t type;
+};
+
+struct control_msg_rsp {
+	uint8_t val;
+};
+
+union sock_msg_sockaddr {
+	struct sockaddr_mctp mctp;
+	struct sockaddr_mctp_ext mctp_ext;
+	struct sockaddr_nl nl;
+	unsigned char buf[56];
+};
+
+struct sock_msg {
+	enum {
+		SOCK_RECV,
+		SOCK_SEND,
+		SOCK_SETSOCKOPT,
+	} type;
+	union {
+		struct sock_msg_recv {
+			union sock_msg_sockaddr addr;
+			socklen_t addrlen;
+			uint8_t data[];
+		} recv;
+		struct sock_msg_send {
+			union sock_msg_sockaddr addr;
+			socklen_t addrlen;
+			uint8_t data[];
+		} send;
+		struct sock_msg_setsockopt {
+			int level;
+			int optname;
+			uint8_t optdata[];
+		} setsockopt;
+	};
+};
+
+

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -1,0 +1,66 @@
+
+import pytest
+
+from mctp_test_utils import mctpd_mctp_obj
+
+""" Test the SetupEndpoint dbus call
+
+Using the default system & network ojects, call SetupEndpoint on our mock
+endpoint. We expect the dbus call to return the endpoint details, and
+the new kernel neighbour and route entries.
+
+We have a few things provided by the test infrastructure:
+
+ - dbus is the dbus connection, call the mctpd_mctp_obj helper to
+   get the MCTP dbus object
+
+ - mctpd is our wrapper for the mctpd process and mock MCTP environment. This
+   has two properties that represent external state:
+
+   mctp.system: the local system info - containing MCTP interfaces
+     (mctp.system.interfaces), addresses (.addresses), neighbours (.neighbours)
+     and routes (.routes). These may be updated by the running mctpd process
+     during tests, over the simlated netlink socket.
+
+   mctp.network: the set of remote MCTP endpoints connected to the system. Each
+     endpoint has a physical address (.lladdr) and an EID (.eid), and a tiny
+     MCTP control protocol implementation, which the mctpd process will
+     interact with over simulated AF_MCTP sockets.
+
+By default, we get some minimal defaults for .system and .network:
+
+ - The system has one interface ('mctp0'), assigned local EID 8. This is
+   similar to a MCTP-over-i2c interface, in that physical addresses are
+   a single byte.
+
+ - The network has one endpoint (lladdr 0x1d) connected to mctp0, with no EID
+   assigned. It also has a random UUID, and advertises support for MCTP
+   Control Protocol and PLDM (but note that it doesn't actually implement
+   any PLDM!).
+
+But these are only defaults; .system and .network can be altered as required
+for each test.
+"""
+async def test_setup_endpoint(dbus, mctpd):
+    # shortcuts to the default system/network configuration
+    iface = mctpd.system.interfaces[0]
+    ep = mctpd.network.endpoints[0]
+
+    # our proxy dbus object for mctpd
+    mctp = await mctpd_mctp_obj(dbus)
+
+    # call SetupEndpoint. This will raise an exception on any dbus error.
+    (eid, net, path, new) = await mctp.call_setup_endpoint(iface.name, ep.lladdr)
+
+    # ep.eid will be updated (through the Set Endpoint ID message); this
+    # should match the returned EID
+    assert eid == ep.eid
+
+    # we should have a neighbour for the new endpoint
+    assert len(mctpd.system.neighbours) == 1
+    neigh = mctpd.system.neighbours[0]
+    assert neigh.lladdr == ep.lladdr
+    assert neigh.eid == ep.eid
+
+    # we should have a route for the new endpoint too
+    assert len(mctpd.system.routes) == 2


### PR DESCRIPTION
This series implements a scriptable test infrastructure for mctpd, mocking both the netlink and AF_MCTP interfaces, to allow arbitrary kernel and external network state.

The majority of the code is a new pytest fixture, which provides small socket interface to an external program (in our case, mctpd), over which the netlink and MCTP communication can be simulated. This allows us to write fairly straightforward tests, including the example in this change:

```python
""" Test the SetupEndpoint dbus call

Using the default system & network ojects, call SetupEndpoint on our mock
endpoint. We expect the dbus call to return the endpoint details, and
the new kernel neighbour and route entries.
"""
async def test_setup_endpoint(dbus, mctpd):
    # shortcuts to the default system/network configuration
    iface = mctpd.system.interfaces[0]
    ep = mctpd.network.endpoints[0]

    # our proxy dbus object for mctpd
    mctp = await mctpd_mctp_obj(dbus)

    # call SetupEndpoint. This will raise an exception on any dbus error.
    (eid, net, path, new) = await mctp.call_setup_endpoint(iface.name, ep.lladdr)

    # ep.eid will be updated (through the Set Endpoint ID message); this
    # should match the returned EID
    assert eid == ep.eid

    # we should have a neighbour for the new endpoint
    assert len(mctpd.system.neighbours) == 1
    neigh = mctpd.system.neighbours[0]
    assert neigh.lladdr == ep.lladdr
    assert neigh.eid == ep.eid

    # we should have a route for the new endpoint too
    assert len(mctpd.system.routes) == 2
```