### PR TITLE
Endpoint recovery fixes

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -2303,29 +2303,31 @@ peer_endpoint_recover(sd_event_source *s, uint64_t usec, void *userdata)
 		uuid_matches_peer = memcmp(uuid, peer->uuid, sizeof(uuid)) == 0;
 		uuid_matches_nil = memcmp(uuid, nil_uuid, sizeof(uuid)) == 0;
 
-		if (rc == 0 && uuid_matches_peer &&
-		    (!uuid_matches_nil || MCTPD_RECOVER_NIL_UUID)) {
-			/* Confirmation of the same device, apply it's already allocated EID */
-			rc = endpoint_send_set_endpoint_id(peer, &new_eid);
-			if (rc < 0) {
-				goto reschedule;
-			}
-
-			if (new_eid != peer->eid) {
-				rc = change_peer_eid(peer, new_eid);
-				if (rc < 0) {
-					goto reclaim;
-				}
-			}
-		} else {
+		if (rc || !uuid_matches_peer ||
+				(uuid_matches_nil && !MCTPD_RECOVER_NIL_UUID)) {
 			/* It's not known to be the same device, allocate a new EID */
 			dest_phys phys = peer->phys;
 
 			assert(sd_event_source_get_enabled(peer->recovery.source, &ev_state) == 0);
 			remove_peer(peer);
-			rc = endpoint_assign_eid(ctx, NULL, &phys, NULL);
+			/*
+			 * The representation of the old peer is now gone. Set up the new peer,
+			 * after which we immediately return as there's no old peer state left to
+			 * maintain.
+			 */
+			return endpoint_assign_eid(ctx, NULL, &phys, &peer);
+		}
+
+		/* Confirmation of the same device, apply its already allocated EID */
+		rc = endpoint_send_set_endpoint_id(peer, &new_eid);
+		if (rc < 0) {
+			goto reschedule;
+		}
+
+		if (new_eid != peer->eid) {
+			rc = change_peer_eid(peer, new_eid);
 			if (rc < 0) {
-				goto reschedule;
+				goto reclaim;
 			}
 		}
 	}


### PR DESCRIPTION
Here are a couple of fixes that were identified with slightly broader testing.

I've exercised these on an AST2600 EVB against a Micron 7450 drive. The drive supports `Get Endpoint UUID` but returns the nil UUID, which isn't terribly helpful, but we have the build feature to deal with it. The three recovery paths have been tested with:

1. Setting up the device's endpoint, removing device power, and leaving it unpowered until recovery fails
2. Building with `-Dunsafe-recover-nil-uuid=false`, setting up the device's endpoint, power-cycling the device, and then invoking a recovery. The original endpoint object was removed, and a new endpoint added, observed via `busctl monitor`
3. Building with `-Dunsafe-recover-nil-uuid=true`, setting up the device's endpoint, power-cycling the device, and then invoking a recovery. The original endpoint object remained, with a signal emitted for `Connectivity` returning to `Available`