### PR TITLE
mctpd: handle EEXIST outside of get_endpoint_peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 1. dbus interface: the NetworkID field is now a `u` rather than an `i`, to
    match OpenBMC's MCTP endpoint specification
 
+### Fixed
+
+1. mctpd: EID assignments now work in the case where a new endpoint has a
+   pre-configured EID that would conflict with other (already enumerated)
+   endpoints. The new endpoint will get a non-conflicting address assigned.
+
 ## [1.1] - 2023-04-13


### PR DESCRIPTION
get_endpoint_peer() may see an EEXIST while updating the local peer tables; this indicates there was a conflict between a queried EID (via Get Endpoint ID to the peer), and another entry in the peer table.

We currently handle this by returning a dbus error directly from get_endpoint_peer(), but this is recoverable from a SetupEndpoint call, by assigning a new EID.

Instead of returning the dbus error in get_endpoint_peer, leave the EXIST handling to the caller, where the behaviours are different:

 - LearnEndpoint needs to propogate the error to the caller

 - SetupEndpoint can attempt to assign a new EID

Fixes: https://github.com/CodeConstruct/mctp/issues/19
Reported-by: Muhammad Usama Chaudhry <chaudhryusama@gmail.com>