### PR TITLE
tests: mctpd endpoint recovery

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,9 @@ class Endpoint:
     def __str__(self):
         return f"uuid {self.uuid} lladdr {self.lladdr}, eid {self.eid}"
 
+    def reset(self):
+        self.eid = 0
+
 class Network:
     def __init__(self):
         self.endpoints = []


### PR DESCRIPTION
There are several paths of interest through recovery:

1. The device is immediately responsive despite the `Recover` invocation
2. The device fails to respond prior to Treclaim
3. The device is initially unresponsive but recovers before Treclaim
4. The device has been exchanged for another

Add test cases for all four.