### PR TITLE
Type support

### DIFF
--- a/src/mctp-req.c
+++ b/src/mctp-req.c
@@ -87,7 +87,10 @@ static int mctp_req(unsigned int net, mctp_eid_t eid,
 			(struct sockaddr *)&addr, &addrlen);
 	if (rc < 0)
 		err(EXIT_FAILURE, "recvfrom");
-	else if ((size_t)rc != len)
+
+	//For a real query, the reponse will likely be longer than
+	//The request.
+	else if ((size_t)rc < len)
 		errx(EXIT_FAILURE, "unexpected length: got %d, exp %zd",
 				rc, len);
 
@@ -109,14 +112,17 @@ static int mctp_req(unsigned int net, mctp_eid_t eid,
 			addr.smctp_haddr[0], addr.smctp_halen);
 	}
 
-	for (i = 0; i < len; i++) {
-		uint8_t exp = data ? data[i] : i & 0xff;
-		if (rxbuf[i] != exp)
-			errx(EXIT_FAILURE,
-				"payload mismatch at byte 0x%zx; "
-					"sent 0x%02x, received 0x%02x",
-				i, exp, rxbuf[i]);
+	for (int j = 0; j < rc; j++) {
+		//uint8_t exp = data ? data[i] : i & 0xff;
+
+		printf("0x%02x ", rxbuf[j]);
+		//if (rxbuf[i] != exp)
+		//	errx(EXIT_FAILURE,
+		//		"payload mismatch at byte 0x%zx; "
+		//			"sent 0x%02x, received 0x%02x",
+		//		i, exp, rxbuf[i]);
 	}
+	printf("\n");
 
 	return 0;
 }

--- a/src/mctp-req.c
+++ b/src/mctp-req.c
@@ -25,7 +25,7 @@ static const size_t DEFAULT_LEN = 1;
 /* lladdrlen != -1 to ignore ifindex/lladdr */
 static int mctp_req(unsigned int net, mctp_eid_t eid,
 	unsigned int ifindex, uint8_t *lladdr, int lladdrlen,
-	uint8_t *data, size_t len)
+	uint8_t *data, size_t len, int type)
 {
 	struct sockaddr_mctp_ext addr;
 	unsigned char *buf, *rxbuf;
@@ -42,7 +42,7 @@ static int mctp_req(unsigned int net, mctp_eid_t eid,
 	addr.smctp_base.smctp_family = AF_MCTP;
 	addr.smctp_base.smctp_network = net;
 	addr.smctp_base.smctp_addr.s_addr = eid;
-	addr.smctp_base.smctp_type = 1;
+	addr.smctp_base.smctp_type = type;
 	addr.smctp_base.smctp_tag = MCTP_TAG_OWNER;
 	printf("req:  sending to (net %d, eid %d), type %d\n",
 		net, eid, addr.smctp_base.smctp_type);
@@ -123,7 +123,7 @@ static int mctp_req(unsigned int net, mctp_eid_t eid,
 
 static void usage(void)
 {
-	fprintf(stderr, "mctp-req [eid <eid>] [net <net>] [ifindex <ifindex> lladdr <hwaddr>] [len <len>]\n");
+	fprintf(stderr, "mctp-req [eid <eid>] [net <net>] [ifindex <ifindex> lladdr <hwaddr>] [len <len>] [type <type>]\n");
 	fprintf(stderr, "default eid %d net %d len %zd\n",
 			DEFAULT_EID, DEFAULT_NET, DEFAULT_LEN);
 }
@@ -138,6 +138,7 @@ int main(int argc, char ** argv)
 	char *endp, *optname, *optval;
 	unsigned int tmp, ifindex;
 	bool valid_parse;
+	int type = 1;
 	int i;
 
 	if (!(argc % 2)) {
@@ -165,7 +166,9 @@ int main(int argc, char ** argv)
 			net = tmp;
 		} else if (!strcmp(optname, "ifindex")) {
 			ifindex = tmp;
-		} else if (!strcmp(optname, "len")) {
+		} else if (!strcmp(optname, "type")) {
+			type = tmp;
+		}  else if (!strcmp(optname, "len")) {
 			if (tmp > 64 * 1024)
 				errx(EXIT_FAILURE, "Bad len");
 			len = tmp;
@@ -199,5 +202,5 @@ int main(int argc, char ** argv)
 	if (data)
 		len = datalen;
 
-	return mctp_req(net, eid, ifindex, lladdr, lladdrlen, data, len);
+	return mctp_req(net, eid, ifindex, lladdr, lladdrlen, data, len, type);
 }


### PR DESCRIPTION
The type code had been hard-coded to 0, which is for MCTP command messages.  However, SPDM requires a type code of 5.  this adds a command line parameter to set the type code.  It leaves the default as 0 if the type parameter is absent.

The second commit removes the error message that comes  back if the request and response are not parallel in size.  This check is only relevant for echo messages, and does not apply for MCTP command or SPDM messages.