### PR TITLE
mctpd: Add AssignEndpointStatic dbus interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 1. mctpd: Add support for endpoint recovery
 2. mctpd: Allow recovery of devices reporting a nil UUID for development
 3. mctpd: Allow configuring .Connectivity as writable for development
+4. mctpd: Add AssignEndpointStatic for static EID allocations
 
 ### Changed
 

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -45,6 +45,20 @@ busctl call xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp \
 Similar to SetupEndpoint, but will always assign an EID rather than querying for existing ones.
 Will return `new = false` when an endpoint is already known to `mctpd`.
 
+### `.AssignEndpointStatic`
+
+Similar to AssignEndpoint, but takes an additional EID argument:
+
+```
+AssignEndpointStatic <interface name> <hwaddr> <static-EID>
+```
+
+to assign `<static-EID>` to the endpoint with hardware address `hwaddr`.
+
+This call will fail if the endpoint already has an EID, and that EID is
+different from `static-EID`, or if `static-EID` is already assigned to another
+endpoint.
+
 ### `.LearnEndpoint`
 
 Like SetupEndpoint but will not assign EIDs, will only query endpoints for a current EID.


### PR DESCRIPTION
Add a new dbus call to create a new peer with a predefined EID, provided by the caller. This allows other infrastructure to define static EID alocations, have mctpd set up the appropriate routes, neighbours and dbus objects, and have the static EID removed from mctpd's EID pool.