### PR TITLE
Change `test` option to `boolean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    bump allows us to exploit some features helpful for chaining the solution
    together.
 
+3. The `tests` option has changed type from `feature` to `boolean`. Tests are
+   enabled by default.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ configure_file(
 )
 
 tests = get_option('tests')
-if tests.allowed()
+if tests
     # The test suite contains integration-style tests that we wish to isolate.
     # The tests drive mctpd's D-Bus interfaces and navigate relevant code paths
     # by mocking kernel and MCTP device behaviour. The mock behaviours are
@@ -114,10 +114,10 @@ if tests.allowed()
     # Invoke pytest via a shell script under `dbus-run-session` so we can
     # override the sanitation of `DBUS_STARTER_BUS_TYPE`, ensuring `test-mctpd`
     # connects to the isolated session bus prepared by `dbus-run-session`.
-    pytest = find_program('pytest', required: tests)
+    pytest = find_program('pytest')
     script = 'export DBUS_STARTER_BUS_TYPE=user ; @0@ --tap'.format(pytest.full_path())
-    sh = find_program('sh', required: tests)
-    dbus_run_session = find_program('dbus-run-session', required: tests)
+    sh = find_program('sh')
+    dbus_run_session = find_program('dbus-run-session')
     test('test-mctpd', dbus_run_session,
         depends: mctpd_test,
         args: [ sh.full_path(), '-c', script ],

--- a/meson.build
+++ b/meson.build
@@ -71,16 +71,6 @@ if libsystemd.found()
     )
 endif
 
-test_conf_data = configuration_data()
-test_conf_data.set('testpaths',
-  join_paths(meson.current_source_dir(), 'tests')
-)
-configure_file(
-    input: 'tests/pytest.ini.in',
-    output: 'pytest.ini',
-    configuration: test_conf_data,
-)
-
 tests = get_option('tests')
 if tests
     # The test suite contains integration-style tests that we wish to isolate.
@@ -118,6 +108,17 @@ if tests
     script = 'export DBUS_STARTER_BUS_TYPE=user ; @0@ --tap'.format(pytest.full_path())
     sh = find_program('sh')
     dbus_run_session = find_program('dbus-run-session')
+
+    test_conf_data = configuration_data()
+    test_conf_data.set('testpaths',
+      join_paths(meson.current_source_dir(), 'tests')
+    )
+    configure_file(
+        input: 'tests/pytest.ini.in',
+        output: 'pytest.ini',
+        configuration: test_conf_data,
+    )
+
     test('test-mctpd', dbus_run_session,
         depends: mctpd_test,
         args: [ sh.full_path(), '-c', script ],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,4 +3,4 @@ option('unsafe-writable-connectivity',
        type: 'boolean',
        value: false,
        description: 'Allow writes to the Connectivity member of the au.com.CodeConstruct.MCTP.Endpoint interface on endpoint objects')
-option('tests', type: 'feature')
+option('tests', type: 'boolean', value: true)


### PR DESCRIPTION
Whether tests should be enabled isn't something that should be auto-detected. Switch the option from `feature` to `boolean`, and cleanup the meson.build file.

The bitbake recipe should be updated to specify the following when bumped:

```
EXTRA_OEMESON = "-Dtests=false"
```