### PR TITLE
Improve checks for MCTP control protocol messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+
 ### Fixed
 
 1. Fixed build on musl; we were relying on an implicit definition for `AF_MCTP`
+
+### Changed
+
+1. We now enforce IID checks on MCTP control protocol responses; this
+   prevents odd behaviour from delayed or invalid responses.
 
 ## [2.0] - 2024-09-19
 

--- a/src/mctp-control-spec.h
+++ b/src/mctp-control-spec.h
@@ -13,6 +13,11 @@ struct mctp_ctrl_msg_hdr {
 	uint8_t command_code;
 } __attribute__((__packed__));
 
+struct mctp_ctrl_resp {
+	struct mctp_ctrl_msg_hdr ctrl_hdr;
+	uint8_t completion_code;
+} __attribute__((packed));
+
 typedef enum {
 	set_eid,
 	force_eid,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,9 @@ class Endpoint:
         else:
 
             raddr = MCTPSockAddr.for_ep_resp(self, addr, sock.addr_ext)
-            hdr = [0x00, opcode]
+            # Use IID from request, zero Rq and D bits
+            hdr = [iid, opcode]
+
             if opcode == 1:
                 # Set Endpoint ID
                 (op, eid) = data[2:]


### PR DESCRIPTION
This series implements more checking on MCTP control protocol responses: that they have the correct opcode and IID values from the request.

In doing so, we use a common error checking path.