### PR TITLE
mctpd: use new Bus Owner name of `au.com.CodeConstruct.MCTP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 3. The `tests` option has changed type from `feature` to `boolean`. Tests are
    enabled by default.
 
+4. Use a dbus owner name of au.com.CodeConstruct.MCTP. We still register the
+   previous name (xyz.openbmc_project.MCTP) for compatibility with existing
+   consumers, but this will be removed in a future release.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The `mctpd` daemon will expose a dbus interface, claiming the bus name
 `xyz.openbmc_project.MCTP` and object path `/xyz/openbmc_project/mctp`. This
 provides a few functions for configuring remote endpoints:
 
-    # busctl introspect xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp
+    # busctl introspect au.com.CodeConstruct.MCTP /xyz/openbmc_project/mctp
     NAME                                TYPE      SIGNATURE  RESULT/VALUE  FLAGS
     au.com.CodeConstruct.MCTP           interface -          -             -
     .AssignEndpoint                     method    say        yisb          -

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -35,7 +35,7 @@ new  (bool) - true if a new EID was assigned
 An example:
 
 ```shell
-busctl call xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp \
+busctl call au.com.CodeConstruct.MCTP /xyz/openbmc_project/mctp \
         au.com.CodeConstruct.MCTP SetupEndpoint say mctpi2c6 1 0x1d
 ```
 `1` is the length of the hwaddr array.
@@ -81,7 +81,7 @@ MTU, configurable with `mctp link set <ifname> mtu <value>`.
 An example, setting MTU of 80:
 
 ```shell
-busctl call xyz.openbmc_project.MCTP  /xyz/openbmc_project/mctp/1/11 \
+busctl call au.com.CodeConstruct.MCTP  /xyz/openbmc_project/mctp/1/11 \
         au.com.CodeConstruct.MCTP.Endpoint  SetMTU u 80
 ```
 

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -42,7 +42,8 @@
 #define CC_MCTP_DBUS_IFACE "au.com.CodeConstruct.MCTP"
 #define CC_MCTP_DBUS_IFACE_ENDPOINT "au.com.CodeConstruct.MCTP.Endpoint"
 #define CC_MCTP_DBUS_IFACE_TESTING "au.com.CodeConstruct.MCTPTesting"
-#define MCTP_DBUS_IFACE "xyz.openbmc_project.MCTP"
+#define MCTP_DBUS_NAME_OBMC "xyz.openbmc_project.MCTP" /* deprecated */
+#define MCTP_DBUS_NAME "au.com.CodeConstruct.MCTP"
 #define MCTP_DBUS_IFACE_ENDPOINT "xyz.openbmc_project.MCTP.Endpoint"
 #define OPENBMC_IFACE_COMMON_UUID "xyz.openbmc_project.Common.UUID"
 
@@ -3134,14 +3135,24 @@ out:
 }
 
 
-int request_dbus(ctx *ctx) {
+int request_dbus(ctx *ctx)
+{
 	int rc;
 
-	rc = sd_bus_request_name(ctx->bus, MCTP_DBUS_IFACE, 0);
+	rc = sd_bus_request_name(ctx->bus, MCTP_DBUS_NAME, 0);
 	if (rc < 0) {
-		warnx("Failed requesting name %s", MCTP_DBUS_IFACE);
+		warnx("Failed requesting dbus name %s", MCTP_DBUS_NAME);
+		return rc;
 	}
-	return rc;
+
+	rc = sd_bus_request_name(ctx->bus, MCTP_DBUS_NAME_OBMC, 0);
+	if (rc < 0) {
+		/* non-fatal, but we do warn */
+		warnx("Failed requesting legacy dbus name %s",
+		      MCTP_DBUS_NAME_OBMC);
+	}
+
+	return 0;
 }
 
 


### PR DESCRIPTION
We currently use a Bus Owner name of `xyz.openbmc_project.MCTP`, to suit conventions with the existing dbus interface names, and MCTP object path structure.

However, mctpd is not under the OpenBMC umbrella, so we should be using our own namespace instead.

Change to a Bus Owner value of `au.com.CodeConstruct.MCTP`, but keep the old value for compatibility. This will be removed in a future release, once we have confidence that consumers are using the new name.