### PR TITLE
mctp-netlink: Add helpers to add or remove addrs and neighs

### DIFF
--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -1063,6 +1063,77 @@ static int linkmap_add_entry(mctp_nl *nl, struct ifinfomsg *info,
 	return 0;
 }
 
+/* Common parts of RTM_NEWADDR and RTM_DELADDR */
+struct mctp_ifaddralter_msg {
+	struct nlmsghdr nh;
+	struct ifaddrmsg ifmsg;
+	struct rtattr rta;
+	uint8_t data[4];
+};
+
+static int fill_ifaddralter_args(struct mctp_nl *nl,
+				 struct mctp_ifaddralter_msg *msg,
+				 struct rtattr **prta, size_t *prta_len,
+				 mctp_eid_t eid, const char *linkstr)
+{
+	int ifindex;
+
+	ifindex = mctp_nl_ifindex_byname(nl, linkstr);
+	if (!ifindex) {
+		warnx("invalid device %s", linkstr);
+		return -1;
+	}
+
+	memset(msg, 0x0, sizeof(*msg));
+
+	msg->nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+
+	msg->ifmsg.ifa_index = ifindex;
+	msg->ifmsg.ifa_family = AF_MCTP;
+
+	msg->rta.rta_type = IFA_LOCAL;
+	msg->rta.rta_len = RTA_LENGTH(sizeof(eid));
+	memcpy(RTA_DATA(&msg->rta), &eid, sizeof(eid));
+
+	msg->nh.nlmsg_len =
+		NLMSG_LENGTH(sizeof(msg->ifmsg)) + RTA_SPACE(sizeof(eid));
+
+	if (prta)
+		*prta = &msg->rta;
+	if (prta_len)
+		*prta_len = msg->rta.rta_len;
+
+	return 0;
+}
+
+int mctp_nl_addr_add(struct mctp_nl *nl, mctp_eid_t eid, const char *linkstr)
+{
+	struct mctp_ifaddralter_msg msg;
+	int rc;
+
+	rc = fill_ifaddralter_args(nl, &msg, NULL, NULL, eid, linkstr);
+	if (rc)
+		return -1;
+
+	msg.nh.nlmsg_type = RTM_NEWADDR;
+
+	return mctp_nl_send(nl, &msg.nh);
+}
+
+int mctp_nl_addr_del(struct mctp_nl *nl, mctp_eid_t eid, const char *linkstr)
+{
+	struct mctp_ifaddralter_msg msg;
+	int rc;
+
+	rc = fill_ifaddralter_args(nl, &msg, NULL, NULL, eid, linkstr);
+	if (rc)
+		return -1;
+
+	msg.nh.nlmsg_type = RTM_DELADDR;
+
+	return mctp_nl_send(nl, &msg.nh);
+}
+
 /* Common parts of RTM_NEWROUTE and RTM_DELROUTE */
 struct mctp_rtalter_msg {
 	struct nlmsghdr		nh;

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -69,6 +69,10 @@ int *mctp_nl_net_list(const mctp_nl *nl, size_t *ret_num_nets);
 /* Returns an allocated list of ifindex, caller to free */
 int *mctp_nl_if_list(const mctp_nl *nl, size_t *ret_num_if);
 
+/* MCTP addr helper */
+int mctp_nl_addr_add(struct mctp_nl *nl, uint8_t eid, const char *ifname);
+int mctp_nl_addr_del(struct mctp_nl *nl, uint8_t eid, const char *ifname);
+
 /* MCTP route helper */
 int mctp_nl_route_add(struct mctp_nl *nl, uint8_t eid, const char* ifname,
 		uint32_t mtu);

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -74,6 +74,11 @@ int mctp_nl_route_add(struct mctp_nl *nl, uint8_t eid, const char* ifname,
 		uint32_t mtu);
 int mctp_nl_route_del(struct mctp_nl *nl, uint8_t eid, const char* ifname);
 
+/* MCTP neigh helper */
+int mctp_nl_neigh_add(struct mctp_nl *nl, uint8_t eid, const char *ifname,
+		      uint8_t *haddr, uint8_t halen);
+int mctp_nl_neigh_del(struct mctp_nl *nl, uint8_t eid, const char *ifname);
+
 /* Helpers */
 
 void* mctp_get_rtnlmsg_attr(int rta_type, struct rtattr *rta, size_t len,


### PR DESCRIPTION
I helped moving some `netlink` specific things into `mctp-netlink`, from `mctp`. Those helpers can be used in `mctpd` in some way in the future.