### PR TITLE
dbus rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 3. The `tests` option has changed type from `feature` to `boolean`. Tests are
    enabled by default.
 
+4. The dbus interface has undergone a major rework, using standard prefixes
+   and version interface, bus owner and entry-point object names. See
+   docs/mctpd.md for full details on the new interface.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ coordinate the local setup and the supervision of the mctpd process.
 An example configuration is in [`conf/mctpd.conf`](conf/mctpd.conf).
 
 The `mctpd` daemon will expose a dbus interface, claiming the bus name
-`xyz.openbmc_project.MCTP` and object path `/xyz/openbmc_project/mctp`. This
+`au.com.codeconstruct.MCTP1` and object path `/au/com/codeconstruct/mctp1`. This
 provides a few functions for configuring remote endpoints:
 
-    # busctl introspect xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp
+    # busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/
     NAME                                TYPE      SIGNATURE  RESULT/VALUE  FLAGS
-    au.com.CodeConstruct.MCTP           interface -          -             -
+    au.com.codeconstruct.MCTP           interface -          -             -
     .AssignEndpoint                     method    say        yisb          -
     .AssignEndpointStatic               method    sayy       yisb          -
     .LearnEndpoint                      method    say        yisb          -
@@ -88,7 +88,7 @@ Results of mctpd enumeration are also represented as dbus objects, using the
 OpenBMC-specified MCTP endpoint format. Each endpoint appears on the bus at the
 object path:
 
-    /xyz/openbmc_project/mctp/<network-id>/<endpoint-id>
+    /au/com/codeconstruct/mctp/networks/<network-id>/endpoints/<endpoint-id>
 
 where `mctpd` exposes three dbus interfaces for each:
 
@@ -103,7 +103,7 @@ where `mctpd` exposes three dbus interfaces for each:
 
    This interface is defined by the Common.UUID phosphor-dbus specification.
 
- - `au.com.CodeConstruct.MCTP.EndPoint`: Additional control methods for the
+ - `au.com.codeconstruct.MCTP1.Endpoint1`: Additional control methods for the
    endpoint - for example, `Remove`
 
 Testing

--- a/conf/mctpd-dbus.conf
+++ b/conf/mctpd-dbus.conf
@@ -3,8 +3,8 @@
         "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
  <policy user="root">
-  <allow own="xyz.openbmc_project.MCTP"/>
-  <allow send_destination="xyz.openbmc_project.MCTP"/>
-  <allow receive_sender="xyz.openbmc_project.MCTP"/>
+  <allow own="au.com.codeconstruct.MCTP1"/>
+  <allow send_destination="au.com.codeconstruct.MCTP1"/>
+  <allow receive_sender="au.com.codeconstruct.MCTP1"/>
  </policy>
 </busconfig>

--- a/conf/mctpd.service
+++ b/conf/mctpd.service
@@ -6,7 +6,7 @@ After=mctp-local.target
 
 [Service]
 Type=dbus
-BusName=xyz.openbmc_project.MCTP
+BusName=au.com.codeconstruct.MCTP1
 ExecStart=/usr/sbin/mctpd
 
 [Install]

--- a/docs/endpoint-recovery.md
+++ b/docs/endpoint-recovery.md
@@ -361,7 +361,7 @@ The general strategy for tracking endpoint lifecycles is [as follows]
    registered as an MCTP endpoint.
 
 2. The FRU data is decoded and `SetupEndpoint` on the
-   `au.com.codeconstruct.MCTP.BusOwner1` interface of the
+   `au.com.codeconstruct.MCTP.BusOwner1.DRAFT` interface of the
    `/au/com/codeconstruct/mctp1`
    object hosted by `mctpd` is invoked.
 
@@ -402,7 +402,7 @@ The general strategy for tracking endpoint lifecycles is [as follows]
    poll the drive CTEMP.
 
 9. `mctpd` [emits a `PropertiesChanged` signal][dbus-spec-standard-interfaces-properties]
-   from `/au/com/codeconstruct/mctp/networks/1/enpoints/9` with the following
+   from `/au/com/codeconstruct/mctp/networks/1/endpoints/9` with the following
    contents:
 
    ```

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -2,20 +2,28 @@
 
 ## D-Bus
 
-`mctpd` provides a D-Bus path of `/xyz/openbmc_project/mctp`. For each known MCTP endpoint, `mctpd`
-will populate an object `/xyz/openbmc_project/mctp/<NetworkId>/<EID>`. The objects have interface
-`xyz.openbmc_project.MCTP.Endpoint`, as per 
-[OpenBMC documentation](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/yaml/xyz/openbmc_project/MCTP).
+`mctpd` provides a D-Bus service named `au.com.codeconstruct.MCTP1`, and a base
+object path of `/au/com/codeconstruct/mctp1`. For each known MCTP endpoint,
+`mctpd` will populate an object at
+`/au/com/codeconstruct/mctp1/networks/<NetworkId>/endpoints/<EID>`. The objects have
+interface `xyz.openbmc_project.MCTP.Endpoint`, as per [OpenBMC
+documentation](https://github.com/openbmc/phosphor-dbus-interfaces/tree/master/yaml/xyz/openbmc_project/MCTP).
 
-As well as the standard interfaces, `mctpd` provides methods to add and configure MCTP endpoints.
-These are provided by the `au.com.CodeConstruct.MCTP` D-Bus interface.
+As well as those standard interfaces, `mctpd` provides methods to add and
+configure MCTP endpoints. These are provided by the `au.com.codeconstruct.MCTP1`
+D-Bus interface.
 
-### `.SetupEndpoint`
+## Bus-owner methods: `au.com.codeconstruct.MCTP.BusOwner1` interface
 
-This method is the normal method used to add a MCTP endpoint.
-The endpoint is identified by MCTP network interface, and physical address.
-`mctpd` will query for the endpoint's current EID, and assign an EID to the endpoint if needed.
-`mctpd` will add local MCTP routes and neighbour table entries for endpoints as they are added.
+This interface exposes bus-owner level functions.
+
+### `.SetupEndpoint`: `say` → `yisb`
+
+This method is the normal method used to add a MCTP endpoint. The endpoint is
+identified by MCTP network interface, and physical address. `mctpd` will query
+for the endpoint's current EID, and assign an EID to the endpoint if needed.
+`mctpd` will add local MCTP routes and neighbour table entries for endpoints as
+they are added.
 
 `SetupEndpoint <interface name> <hwaddr>`
 
@@ -29,23 +37,27 @@ new  (bool) - true if a new EID was assigned
 
 `<interface name>` is an interface such as `mctpi2c6`.
 
-`<hwaddr>` depends on the transport type - for i2c it is a 1 byte client address (7-bit, the same as other Linux tools like `i2cdetect`).
+`<hwaddr>` depends on the transport type - for i2c it is a 1 byte client address
+(7-bit, the same as other Linux tools like `i2cdetect`).
 
 
 An example:
 
 ```shell
-busctl call xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp \
-        au.com.CodeConstruct.MCTP SetupEndpoint say mctpi2c6 1 0x1d
+busctl call au.com.codeconstruct.MCTP1 \
+    /au/com/codeconstruct/mctp1 \
+    au.com.codeconstruct.MCTP1 \
+    SetupEndpoint say mctpi2c6 1 0x1d
 ```
 `1` is the length of the hwaddr array.
 
-### `.AssignEndpoint`
+### `.AssignEndpoint`: `say` → `yisb`
 
-Similar to SetupEndpoint, but will always assign an EID rather than querying for existing ones.
-Will return `new = false` when an endpoint is already known to `mctpd`.
+Similar to SetupEndpoint, but will always assign an EID rather than querying for
+existing ones. Will return `new = false` when an endpoint is already known to
+`mctpd`.
 
-### `.AssignEndpointStatic`
+### `.AssignEndpointStatic`: `sayy` → `yisb`
 
 Similar to AssignEndpoint, but takes an additional EID argument:
 
@@ -59,35 +71,36 @@ This call will fail if the endpoint already has an EID, and that EID is
 different from `static-EID`, or if `static-EID` is already assigned to another
 endpoint.
 
-### `.LearnEndpoint`
+### `.LearnEndpoint`: `say` → `yisb`
 
-Like SetupEndpoint but will not assign EIDs, will only query endpoints for a current EID.
-The `new` return value is set to `false` for an already known endpoint, or `true` when an
-endpoint's EID is newly discovered.
+Like SetupEndpoint but will not assign EIDs, will only query endpoints for a
+current EID. The `new` return value is set to `false` for an already known
+endpoint, or `true` when an endpoint's EID is newly discovered.
 
-## Endpoint Methods
+## Endpoint methods: the `au.com.codeconstruct.MCTP.Endpoint1` interface
 
-Each endpoint object has methods to configure it, with `au.com.CodeConstruct.MCTP.Endpoint`
-interface on each endpoint.
+Each endpoint object has methods to configure it, through the
+`au.com.codeconstruct.MCTP.Endpoint1` interface on each endpoint.
 
-## `.SetMTU`
+## `.SetMTU`: `u`
 
-Sets the MTU (maximum transmission unit) on the route for that endpoint. This must be within
-the MTU range allowed for the network device. For i2c that is [68, 254].
+Sets the MTU (maximum transmission unit) on the route for that endpoint. This
+must be within the MTU range allowed for the network device. For i2c that is
+[68, 254].
 
-If a route-specific MTU has not been set (or set to 0), Linux will use the per-interface
-MTU, configurable with `mctp link set <ifname> mtu <value>`.
+If a route-specific MTU has not been set (or set to 0), Linux will use the
+per-interface MTU, configurable with `mctp link set <ifname> mtu <value>`.
 
 An example, setting MTU of 80:
 
 ```shell
-busctl call xyz.openbmc_project.MCTP  /xyz/openbmc_project/mctp/1/11 \
-        au.com.CodeConstruct.MCTP.Endpoint  SetMTU u 80
+busctl call au.com.codeconstruct.MCTP1 \
+    /au/com/codeconstruct/mctp1/networks/1/endpoints/11 \
+    au.com.codeconstruct.MCTP.Endpoint1 \
+    SetMTU u 80
 ```
 
 ## `.Remove`
 
 Removes the MCTP endpoint from `mctpd`, and deletes routes and neighbour entries.
-
-
 

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -13,7 +13,7 @@ As well as those standard interfaces, `mctpd` provides methods to add and
 configure MCTP endpoints. These are provided by the `au.com.codeconstruct.MCTP1`
 D-Bus interface.
 
-## Bus-owner methods: `au.com.codeconstruct.MCTP.BusOwner1` interface
+## Bus-owner methods: `au.com.codeconstruct.MCTP.BusOwner1.DRAFT` interface
 
 This interface exposes bus-owner level functions.
 

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ conf.set10('MCTPD_RECOVER_NIL_UUID',
 )
 conf.set10('MCTPD_WRITABLE_CONNECTIVITY',
     get_option('unsafe-writable-connectivity'),
-    description: 'Allow writes to the Connectivity member of the au.com.CodeConstruct.MCTP.Endpoint interface on endpoint objects')
+    description: 'Allow writes to the Connectivity member of the au.com.codeconstruct.MCTP.Endpoint1 interface on endpoint objects')
 
 conf.set_quoted('MCTPD_CONF_FILE_DEFAULT',
     join_paths(get_option('prefix'), get_option('sysconfdir'), 'mctpd.conf'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,5 +2,5 @@ option('unsafe-recover-nil-uuid', type: 'boolean', value: false)
 option('unsafe-writable-connectivity',
        type: 'boolean',
        value: false,
-       description: 'Allow writes to the Connectivity member of the au.com.CodeConstruct.MCTP.Endpoint interface on endpoint objects')
+       description: 'Allow writes to the Connectivity member of the au.com.codeconstruct.MCTP.Endpoint1 interface on endpoint objects')
 option('tests', type: 'boolean', value: true)

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -41,7 +41,7 @@
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
 #define MCTP_DBUS_PATH "/au/com/codeconstruct/mctp1"
-#define CC_MCTP_DBUS_IFACE_BUSOWNER "au.com.codeconstruct.MCTP.BusOwner1"
+#define CC_MCTP_DBUS_IFACE_BUSOWNER "au.com.codeconstruct.MCTP.BusOwner1.DRAFT"
 #define CC_MCTP_DBUS_IFACE_ENDPOINT "au.com.codeconstruct.MCTP.Endpoint1"
 #define CC_MCTP_DBUS_IFACE_TESTING "au.com.codeconstruct.MCTPTesting"
 #define MCTP_DBUS_NAME "au.com.codeconstruct.MCTP1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -901,7 +901,7 @@ class MctpdWrapper:
 
         s = trio.Semaphore(initial_value = 0)
         def name_owner_changed(name, new_owner, old_owner):
-            if name == 'xyz.openbmc_project.MCTP':
+            if name == 'au.com.codeconstruct.MCTP1':
                 s.release()
 
         await interface.on_name_owner_changed(name_owner_changed)

--- a/tests/mctp_test_utils.py
+++ b/tests/mctp_test_utils.py
@@ -1,14 +1,14 @@
 
 async def mctpd_mctp_obj(dbus):
     obj = await dbus.get_proxy_object(
-            'xyz.openbmc_project.MCTP',
-            '/xyz/openbmc_project/mctp'
+            'au.com.codeconstruct.MCTP1',
+            '/au/com/codeconstruct/mctp1'
         )
-    return await obj.get_interface('au.com.CodeConstruct.MCTP')
+    return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1')
 
 async def mctpd_mctp_endpoint_obj(dbus, path):
     obj = await dbus.get_proxy_object(
-            'xyz.openbmc_project.MCTP',
+            'au.com.codeconstruct.MCTP1',
             path,
         )
-    return await obj.get_interface('au.com.CodeConstruct.MCTP.Endpoint')
+    return await obj.get_interface('au.com.codeconstruct.MCTP.Endpoint1')

--- a/tests/mctp_test_utils.py
+++ b/tests/mctp_test_utils.py
@@ -4,7 +4,7 @@ async def mctpd_mctp_obj(dbus):
             'au.com.codeconstruct.MCTP1',
             '/au/com/codeconstruct/mctp1'
         )
-    return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1')
+    return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1.DRAFT')
 
 async def mctpd_mctp_endpoint_obj(dbus, path):
     obj = await dbus.get_proxy_object(

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -13,7 +13,7 @@ from conftest import Endpoint
 # - I: Interface
 MCTPD_C = 'au.com.codeconstruct.MCTP1'
 MCTPD_MCTP_P = '/au/com/codeconstruct/mctp1'
-MCTPD_MCTP_I = 'au.com.codeconstruct.MCTP.BusOwner1'
+MCTPD_MCTP_I = 'au.com.codeconstruct.MCTP.BusOwner1.DRAFT'
 MCTPD_ENDPOINT_I = 'au.com.codeconstruct.MCTP.Endpoint1'
 DBUS_OBJECT_MANAGER_I = 'org.freedesktop.DBus.ObjectManager'
 DBUS_PROPERTIES_I = 'org.freedesktop.DBus.Properties'

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -11,10 +11,10 @@ from conftest import Endpoint
 # - C: Connection
 # - P: Path
 # - I: Interface
-MCTPD_C = 'xyz.openbmc_project.MCTP'
-MCTPD_MCTP_P = '/xyz/openbmc_project/mctp'
-MCTPD_MCTP_I = 'au.com.CodeConstruct.MCTP'
-MCTPD_ENDPOINT_I = 'au.com.CodeConstruct.MCTP.Endpoint'
+MCTPD_C = 'au.com.codeconstruct.MCTP1'
+MCTPD_MCTP_P = '/au/com/codeconstruct/mctp1'
+MCTPD_MCTP_I = 'au.com.codeconstruct.MCTP.BusOwner1'
+MCTPD_ENDPOINT_I = 'au.com.codeconstruct.MCTP.Endpoint1'
 DBUS_OBJECT_MANAGER_I = 'org.freedesktop.DBus.ObjectManager'
 DBUS_PROPERTIES_I = 'org.freedesktop.DBus.Properties'
 


### PR DESCRIPTION
This PR implements the dbus rework discussed in #40. From the interface commit:


> Essentially: this uses more standard bus, object and path names, and
> moves away from the xyz.openbmc_project namespace, and use
> au.com.codeconstruct (all lowercase) there instead, as we're not
> specificially an OpenBMC project.
> 
> We also put collections of things (networks and endpoints) under a
> specifically-named object path, so we can introduce new collections
> alongside (interfaces) without compatibility issues
> 
> This means:
> 
>  - the bus owner name is now au.com.codeconstruct.MCTP1
> 
>  - interfaces are namespaced and versioned:
>     - au.com.codeconstruct.MCTP.Endpoint1
>     - au.com.codeconstruct.MCTP.BusOwner1
> 
>  - the top-level entrypoint path is versioned, as
>     `/au/com/codeconstruct/mctp1`
> 
>  - the endpoint object tree is structured as
>     `/au/com/codeconstruct/mctp1/networks/<n>/endpoints/<e>`
> 

Closes: #40 