### PR TITLE
dbus `BusOwner` rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    and version interface, bus owner and entry-point object names. See
    docs/mctpd.md for full details on the new interface.
 
+5. In line with the above, bus-owner related dbus methods (SetupEndpoint and
+   friends) now exist on the MCTP interface objects, and only when those
+   interface objects have the bus owner role. Because those methods are
+   now associated with the interface object, they no longer take the
+   interface name as their first argument.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/README.md
+++ b/README.md
@@ -73,16 +73,18 @@ coordinate the local setup and the supervision of the mctpd process.
 An example configuration is in [`conf/mctpd.conf`](conf/mctpd.conf).
 
 The `mctpd` daemon will expose a dbus interface, claiming the bus name
-`au.com.codeconstruct.MCTP1` and object path `/au/com/codeconstruct/mctp1`. This
-provides a few functions for configuring remote endpoints:
+`au.com.codeconstruct.MCTP1` and object path `/au/com/codeconstruct/mctp1`.
 
-    # busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/
-    NAME                                TYPE      SIGNATURE  RESULT/VALUE  FLAGS
-    au.com.codeconstruct.MCTP           interface -          -             -
-    .AssignEndpoint                     method    say        yisb          -
-    .AssignEndpointStatic               method    sayy       yisb          -
-    .LearnEndpoint                      method    say        yisb          -
-    .SetupEndpoint                      method    say        yisb          -
+Each detected MCTP interface on the system provides a few functions for
+configuring remote endpoints on that bus:
+
+    # busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/interfaces/mctpi2c1
+    NAME                                 TYPE      SIGNATURE  RESULT/VALUE  FLAGS
+    au.com.codeconstruct.MCTP.Interface1 interface -          -             -
+    .AssignEndpoint                      method    ay         yisb          -
+    .AssignEndpointStatic                method    ayy        yisb          -
+    .LearnEndpoint                       method    ay         yisb          -
+    .SetupEndpoint                       method    ay         yisb          -
 
 Results of mctpd enumeration are also represented as dbus objects, using the
 OpenBMC-specified MCTP endpoint format. Each endpoint appears on the bus at the

--- a/docs/endpoint-recovery.md
+++ b/docs/endpoint-recovery.md
@@ -149,6 +149,7 @@ root@cc-nvme-mi:~# busctl tree au.com.codeconstruct.MCTP1
   └─/au/com
     └─/au/com/codeconstruct
       └─/au/com/codeconstruct/mctp1
+        ├─/au/com/codeconstruct/mctp1/interfaces/mctpi2c0
         ├─/au/com/codeconstruct/mctp1/networks/1
         │ └─/au/com/codeconstruct/mctp1/networks/1/endpoints/12
           ├─/au/com/codeconstruct/mctp1/networks/1/endpoints/8
@@ -158,16 +159,31 @@ root@cc-nvme-mi:~# busctl tree au.com.codeconstruct.MCTP1
 ```
 root@cc-nvme-mi:~# busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1
 NAME                                TYPE      SIGNATURE  RESULT/VALUE  FLAGS
-au.com.codeconstruct.Endpoint1      interface -          -             -
-.AssignEndpoint                     method    say        yisb          -
-.LearnEndpoint                      method    say        yisb          -
-.SetupEndpoint                      method    say        yisb          -
 org.freedesktop.DBus.Introspectable interface -          -             -
 .Introspect                         method    -          s             -
 org.freedesktop.DBus.ObjectManager  interface -          -             -
 .GetManagedObjects                  method    -          a{oa{sa{sv}}} -
 .InterfacesAdded                    signal    oa{sa{sv}} -             -
 .InterfacesRemoved                  signal    oas        -             -
+org.freedesktop.DBus.Peer           interface -          -             -
+.GetMachineId                       method    -          s             -
+.Ping                               method    -          -             -
+org.freedesktop.DBus.Properties     interface -          -             -
+.Get                                method    ss         v             -
+.GetAll                             method    s          a{sv}         -
+.Set                                method    ssv        -             -
+.PropertiesChanged                  signal    sa{sv}as   -             -
+```
+
+```
+root@cc-nvme-mi:~# busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/interfaces/mctpi2c0
+NAME                                TYPE      SIGNATURE  RESULT/VALUE  FLAGS
+au.com.codeconstruct.Interface1     interface -          -             -
+.AssignEndpoint                     method    ay         yisb          -
+.LearnEndpoint                      method    ay         yisb          -
+.SetupEndpoint                      method    ay         yisb          -
+org.freedesktop.DBus.Introspectable interface -          -             -
+.Introspect                         method    -          s             -
 org.freedesktop.DBus.Peer           interface -          -             -
 .GetMachineId                       method    -          s             -
 .Ping                               method    -          -             -
@@ -361,8 +377,8 @@ The general strategy for tracking endpoint lifecycles is [as follows]
    registered as an MCTP endpoint.
 
 2. The FRU data is decoded and `SetupEndpoint` on the
-   `au.com.codeconstruct.MCTP.BusOwner1.DRAFT` interface of the
-   `/au/com/codeconstruct/mctp1`
+   `au.com.codeconstruct.MCTP.BusOwner1` interface of the
+   `/au/com/codeconstruct/mctp1/interfaces/<interface>`
    object hosted by `mctpd` is invoked.
 
 3. The device was not previously configured and has no programmed static EID.

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -13,19 +13,20 @@ As well as those standard interfaces, `mctpd` provides methods to add and
 configure MCTP endpoints. These are provided by the `au.com.codeconstruct.MCTP1`
 D-Bus interface.
 
-## Bus-owner methods: `au.com.codeconstruct.MCTP.BusOwner1.DRAFT` interface
+## Bus-owner methods: `au.com.codeconstruct.MCTP.BusOwner1` interface
 
-This interface exposes bus-owner level functions.
+This interface exposes bus-owner level functions, on each interface object that
+represents the bus-owner side of a transport.
 
-### `.SetupEndpoint`: `say` → `yisb`
+### `.SetupEndpoint`: `ay` → `yisb`
 
-This method is the normal method used to add a MCTP endpoint. The endpoint is
-identified by MCTP network interface, and physical address. `mctpd` will query
-for the endpoint's current EID, and assign an EID to the endpoint if needed.
-`mctpd` will add local MCTP routes and neighbour table entries for endpoints as
-they are added.
+This method is the normal method used to add a MCTP endpoint on this interface.
+The endpoint is identified by physical address. `mctpd` will query for the
+endpoint's current EID, and assign an EID to the endpoint if needed. `mctpd`
+will add local MCTP routes and neighbour table entries for endpoints as they are
+added.
 
-`SetupEndpoint <interface name> <hwaddr>`
+`SetupEndpoint <hwaddr>`
 
 Returns
 ```
@@ -45,24 +46,24 @@ An example:
 
 ```shell
 busctl call au.com.codeconstruct.MCTP1 \
-    /au/com/codeconstruct/mctp1 \
-    au.com.codeconstruct.MCTP1 \
-    SetupEndpoint say mctpi2c6 1 0x1d
+    /au/com/codeconstruct/mctp1/interfaces/mctpi2c6 \
+    au.com.codeconstruct.MCTP.Interface1 \
+    SetupEndpoint ay 1 0x1d
 ```
 `1` is the length of the hwaddr array.
 
-### `.AssignEndpoint`: `say` → `yisb`
+### `.AssignEndpoint`: `ay` → `yisb`
 
 Similar to SetupEndpoint, but will always assign an EID rather than querying for
 existing ones. Will return `new = false` when an endpoint is already known to
 `mctpd`.
 
-### `.AssignEndpointStatic`: `sayy` → `yisb`
+### `.AssignEndpointStatic`: `ayy` → `yisb`
 
 Similar to AssignEndpoint, but takes an additional EID argument:
 
 ```
-AssignEndpointStatic <interface name> <hwaddr> <static-EID>
+AssignEndpointStatic <hwaddr> <static-EID>
 ```
 
 to assign `<static-EID>` to the endpoint with hardware address `hwaddr`.
@@ -71,7 +72,7 @@ This call will fail if the endpoint already has an EID, and that EID is
 different from `static-EID`, or if `static-EID` is already assigned to another
 endpoint.
 
-### `.LearnEndpoint`: `say` → `yisb`
+### `.LearnEndpoint`: `ay` → `yisb`
 
 Like SetupEndpoint but will not assign EIDs, will only query endpoints for a
 current EID. The `new` return value is set to `false` for an already known

--- a/tests/mctp_test_utils.py
+++ b/tests/mctp_test_utils.py
@@ -1,10 +1,10 @@
 
-async def mctpd_mctp_obj(dbus):
+async def mctpd_mctp_iface_obj(dbus, iface):
     obj = await dbus.get_proxy_object(
             'au.com.codeconstruct.MCTP1',
-            '/au/com/codeconstruct/mctp1'
+            '/au/com/codeconstruct/mctp1/interfaces/' + iface.name
         )
-    return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1.DRAFT')
+    return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1')
 
 async def mctpd_mctp_endpoint_obj(dbus, path):
     obj = await dbus.get_proxy_object(


### PR DESCRIPTION
In https://github.com/CodeConstruct/mctp/commit/9b4eabc3a5e4af5d3f39cd59ddfcc059fe39b961 ("mctpd: use .DRAFT suffix on BusOwner1 interface"), we
renamed BusOwner1 to BusOwner1.DRAFT while it was present on the
top-level dbus object.

Now that we have the interface objects present, we can move the BusOwner
interfaces to their proper location on those interfaces, and drop the
DRAFT1 suffix.

Because we already know the object, we no longer need the interface name
string as the first argument to all calls.