### PR TITLE
docs: Drop dangling instruction in endpoint recovery

### DIFF
--- a/docs/endpoint-recovery.md
+++ b/docs/endpoint-recovery.md
@@ -369,8 +369,6 @@ The general strategy for tracking endpoint lifecycles is [as follows]
 2. Issue a call to `GetManagedObjects` `org.freedesktop.DBus.ObjectManager` on
    `/au/com/codeconstruct/mctp1` for initial population of local data-structures
 
-3. Issue
-
 ### An example order of MCTP device events, consumed by `nvmesensor`
 
 1. A series of events yields a new FRU EEPROM device on an I2C bus already


### PR DESCRIPTION
Apparently I got half-way through a thought before getting distracted. Remove the unfinished description until the thought comes back.

Fixes: #47
Fixes: 7ec2f8daa3a8 ("mctpd: Add support for endpoint recovery")