### PR TITLE
mctp: Improve formatting of interface addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    now associated with the interface object, they no longer take the
    interface name as their first argument.
 
+6. Hardware address formatting has been improved in cases where the address
+   size is something other than a 1-byte value.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/src/mctp.c
+++ b/src/mctp.c
@@ -213,12 +213,16 @@ static int display_ifinfo(struct ctx *ctx, void *p, size_t len) {
 	updown = msg->ifi_flags & IFF_UP ? "up" : "down";
 	// not sure if will be NULL terminated, handle either
 	name_len = strnlen(name, name_len);
-	printf("dev %*s index %d address 0x",
+	printf("dev %*s index %d address ",
 		(int)name_len, name, msg->ifi_index);
+	if (addr_len == 1) {
+		// make it clear that it is hex not decimal
+		printf("0x");
+	}
 	if (addr && addr_len)
 		print_hex_addr(addr, addr_len);
 	else
-		printf("(no-addr)");
+		printf("none");
 	printf(" net %d mtu %d %s\n", net, mtu, updown);
 	return 0;
 }


### PR DESCRIPTION
0x prefix is only added for single-byte addresses, "none" is printed instead of (no-addr).