### PR TITLE
mctpd: Set initial route MTU to interface minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    now associated with the interface object, they no longer take the
    interface name as their first argument.
 
+6. In mctpd the initial route MTU for an endpoint is now set to the minimum MTU
+   of the interface. This allows better compatibility with devices that 
+   have a low initial allowed packet size and require application negotiation
+   to increase that packet size. Previously the initial MTU was left as the
+   interface default (normally the maximum MTU).
+   The .SetMTU method can be used to set the endpoint route MTU.
+
 ### Fixed
 
 1. mctpd: EID assignments now work in the case where a new endpoint has a

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -64,6 +64,10 @@ int mctp_nl_ifindex_byname(const mctp_nl *nl, const char *ifname);
 const char* mctp_nl_if_byindex(const mctp_nl *nl, int index);
 int mctp_nl_net_byindex(const mctp_nl *nl, int index);
 bool mctp_nl_up_byindex(const mctp_nl *nl, int index);
+/* Returns interface min_mtu, or 0 if bad index */
+uint32_t mctp_nl_min_mtu_byindex(const mctp_nl *nl, int index);
+/* Returns interface max_mtu, or 0 if bad index */
+uint32_t mctp_nl_max_mtu_byindex(const mctp_nl *nl, int index);
 /* Caller to free */
 mctp_eid_t *mctp_nl_addrs_byindex(const mctp_nl *nl, int index,
 	size_t *ret_num);

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -146,7 +146,8 @@ struct peer {
 	bool have_neigh;
 	bool have_route;
 
-	// set by SetMTU method, 0 otherwise
+	// MTU for the route. Set to the interface's minimum MTU initially,
+	// or changed by .SetMTU method
 	uint32_t mtu;
 
 	// malloc()ed list of supported message types, from Get Message Type
@@ -2160,6 +2161,10 @@ static int peer_route_update(peer *peer, uint16_t type)
 static int setup_added_peer(peer *peer)
 {
 	int rc;
+
+	// Set minimum MTU by default for compatibility. Clients can increase
+	// this with .SetMTU as needed
+	peer->mtu = mctp_nl_min_mtu_byindex(peer->ctx->nl_query, peer->phys.ifindex);
 
 	// add route before querying
 	add_peer_route(peer);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,12 +40,18 @@ class NetlinkError(Exception):
 
 class System:
     class Interface:
-        def __init__(self, name, ifindex, net, lladdr, mtu, up = False):
+        """Interface constructor.
+
+        Initial mtu is set to max_mtu.
+        """
+        def __init__(self, name, ifindex, net, lladdr, min_mtu, max_mtu, up = False):
             self.name = name
             self.ifindex = ifindex
             self.net = net
             self.lladdr = lladdr,
-            self.mtu = mtu
+            self.min_mtu = min_mtu
+            self.max_mtu = max_mtu
+            self.mtu = max_mtu
             self.up = up
 
         def __str__(self):
@@ -652,6 +658,8 @@ class NLSocket(BaseSocket):
                 ['IFLA_IFNAME', iface.name],
                 ['IFLA_ADDRESS', iface.lladdr],
                 ['IFLA_MTU', iface.mtu],
+                ['IFLA_MIN_MTU', iface.min_mtu],
+                ['IFLA_MAX_MTU', iface.max_mtu],
                 ['IFLA_AF_SPEC', {
                     'attrs': [['AF_MCTP', {
                         'attrs': [['IFLA_MCTP_NET', iface.net]],
@@ -929,15 +937,15 @@ class MctpdWrapper:
 
 Sysnet = namedtuple('SysNet', ['system', 'network'])
 
+"""Simple system & network.
+
+Contains one interface (lladdr 0x10, local EID 8), and one endpoint (lladdr
+0x1d), that reports support for MCTP control and PLDM.
+"""
 @pytest.fixture
 async def sysnet():
-    """Simple system & network.
-
-    Contains one interface (lladdr 0x10, local EID 8), and one endpoint (lladdr
-    0x1d), that reports support for MCTP control and PLDM.
-    """
     system = System()
-    iface = System.Interface('mctp0', 1, 1, bytes([0x10]), 68, True)
+    iface = System.Interface('mctp0', 1, 1, bytes([0x10]), 68, 254, True)
     system.add_interface(iface)
     system.add_address(System.Address(iface, 8))
 


### PR DESCRIPTION
This allows better compatibility with devices that have a low initial allowed packet size and require application negotiation to increase that packet size.

Previously the MTU was left at 0, so matching the currently set MTU of the device.