### PR TITLE
Support `LocaEids` property in `au.com.codeconstruct.MCTP.Network1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 1. New debug tool, `mctp-bench`, for sending and receiving a stream of MCTP
    messages between two processes.
 
+2. mctpd: Add `au.com.codeconstruct.MCTP.Network1` interface
+
 ## [2.1] - 2024-12-16
 
 ### Fixed

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -143,6 +143,27 @@ Like SetupEndpoint but will not assign EIDs, will only query endpoints for a
 current EID. The `new` return value is set to `false` for an already known
 endpoint, or `true` when an endpoint's EID is newly discovered.
 
+## Network objects: `/au/com/codeconstruct/networks/<net>`
+
+These objects represent MCTP networks which have been added use `mctp link`
+commands. These will be 1:1 with the MCTP networks on the system.
+
+These objects host the interface `au.com.codeconstruct.MCTP.Network1`.
+
+### MCTP network interface: `au.com.codeconstruct.MCTP.Network1`
+
+All MCTP networks objects host the `au.com.codeconstruct.MCTP.Network1` dbus
+interface:
+
+```
+NAME                                 TYPE      SIGNATURE RESULT/VALUE FLAGS
+au.com.codeconstruct.MCTP.Network1  interface -         -            -
+.LocalEIDs                          property  ay        1 8          const
+```
+
+The D-Bus interface includes the `LocalEIDs` property which reports BMC local EIDs
+in the network.
+
 ## Endpoint objects: `/au/com/codeconstruct/networks/<net>/endpoints/<eid>`
 
 These objects represent MCTP endpoints that `mctpd` has either discovered


### PR DESCRIPTION
Add code to show the local EIDs in `EIDs` property in `au.com.CodeConstruct.MCTP.Interface1` D-Bus interface.

```
busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/interfaces/mctpi2c3
NAME                                 TYPE      SIGNATURE RESULT/VALUE FLAGS
au.com.CodeConstruct.MCTP.Interface1 interface -         -            -
.EIDs                                property  ay        1 8          const
```