### PR TITLE
mctp-bench: Adjust headers

### DIFF
--- a/src/mctp-bench.c
+++ b/src/mctp-bench.c
@@ -1,5 +1,5 @@
 #define _XOPEN_SOURCE 700
-#include <bits/time.h>
+#include <time.h>
 #include <err.h>
 #include <errno.h>
 #include <poll.h>
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
 #include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
bits/time.h is not be included directly, instead use time.h since poll.h is included there is no need to include sys/poll.h

Fixes
../git/src/mctp-bench.c:2:10: fatal error: 'bits/time.h' file not found
    2 | #include <bits/time.h>
      |          ^~~~~~~~~~~~~