### PR TITLE
Use Vendor message types for mctp-bench, mctp-echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
        (cd obj; python3 ../tests/mctpd/__init__.py)
 
+3. mctp-bench, mctp-req, mctp-echo: Message format has changed to use a
+   vendor-defined message type, rather than MCTP type 1.
+
 ## [2.1] - 2024-12-16
 
 ### Fixed

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -1041,7 +1041,7 @@ uint32_t *mctp_nl_net_list(const mctp_nl *nl, size_t *ret_num_nets)
 
 	*ret_num_nets = 0;
 	// allocation may be oversized, that's OK
-	nets = calloc(sizeof(uint32_t), nl->linkmap_count);
+	nets = calloc(nl->linkmap_count, sizeof(uint32_t));
 	if (!nets) {
 		warnx("Allocation failed");
 		return NULL;


### PR DESCRIPTION
Previously PLDM message type (1) was being used, but it would be better to use a specific type that won't conflict with other uses.

This could still clash with other vendor types, pending future kernel support to distinguish those.