### PR TITLE
Fix mctpd deleted interface handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ cd obj
 pytest
 ```
 
+To run without an existing dbus session:
+```sh
+dbus-run-session env DBUS_STARTER_BUS_TYPE=user pytest
+```
+
 The test infrastructure depends on a few python packages, including the pytest
 binary. You can use a python `venv` to provide these:
 

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -859,7 +859,7 @@ static int fill_local_addrs(mctp_nl *nl)
 
 		entry = entry_byindex(nl, ifa->ifa_index);
 		if (!entry) {
-			warnx("kernel returned address for unknown if");
+			warnx("kernel returned address for unknown if %d", ifa->ifa_index);
 			continue;
 		}
 		tmp = realloc(entry->local_eids,

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -331,13 +331,13 @@ void mctp_nl_changes_dump(mctp_nl *nl, mctp_nl_change *changes, size_t num_chang
 		"ADD_EID", "DEL_EID",
 	};
 
-	printf("%zu changes:\n", num_changes);
+	fprintf(stderr, "%zu changes:\n", num_changes);
 	for (size_t i = 0; i < num_changes; i++) {
 		mctp_nl_change *ch = &changes[i];
 		const char* ifname = mctp_nl_if_byindex(nl, ch->ifindex);
 		if (!ifname)
 			ifname = "deleted";
-		printf("%3zd %-12s ifindex %3d (%-20s) eid %3d old_net %4d old_up %d\n",
+		fprintf(stderr, "%3zd %-12s ifindex %3d (%-20s) eid %3d old_net %4d old_up %d\n",
 			i, ops[ch->op], ch->ifindex, ifname, ch->eid,
 			ch->old_net, ch->old_up);
 	}
@@ -910,19 +910,19 @@ void mctp_nl_linkmap_dump(const mctp_nl *nl)
 {
 	size_t i, j;
 
-	printf("linkmap\n");
+	fprintf(stderr, "linkmap\n");
 	for (i = 0; i < nl->linkmap_count; i++) {
 		struct linkmap_entry *entry = &nl->linkmap[i];
 		const char* updown = entry->up ? "up" : "DOWN";
-		printf("  %2d: %s, net %d %s local addrs [",
+		fprintf(stderr, "  %2d: %s, net %d %s local addrs [",
 			entry->ifindex, entry->ifname,
 			entry->net, updown);
 		for (j = 0; j < entry->num_local; j++) {
 			if (j != 0)
-				printf(", ");
-			printf("%d", entry->local_eids[j]);
+				fprintf(stderr, ", ");
+			fprintf(stderr, "%d", entry->local_eids[j]);
 		}
-		printf("]\n");
+		fprintf(stderr, "]\n");
 	}
 }
 

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -68,6 +68,8 @@ bool mctp_nl_up_byindex(const mctp_nl *nl, int index);
 uint32_t mctp_nl_min_mtu_byindex(const mctp_nl *nl, int index);
 /* Returns interface max_mtu, or 0 if bad index */
 uint32_t mctp_nl_max_mtu_byindex(const mctp_nl *nl, int index);
+/* Returns negative errno on failure */
+int mctp_nl_hwaddr_len_byindex(const mctp_nl *nl, int index, size_t *ret_hwaddr_len);
 /* Caller to free */
 mctp_eid_t *mctp_nl_addrs_byindex(const mctp_nl *nl, int index,
 	size_t *ret_num);

--- a/src/mctp-ops.c
+++ b/src/mctp-ops.c
@@ -9,6 +9,7 @@
 
 #include <unistd.h>
 #include <linux/netlink.h>
+#include <err.h>
 
 #include "mctp.h"
 #include "mctp-ops.h"
@@ -51,6 +52,11 @@ static int mctp_op_close(int sd)
 	return close(sd);
 }
 
+static void mctp_bug_warn(const char* fmt, va_list args)
+{
+	vwarnx(fmt, args);
+}
+
 const struct mctp_ops mctp_ops = {
 	.mctp = {
 		.socket = mctp_op_mctp_socket,
@@ -68,6 +74,7 @@ const struct mctp_ops mctp_ops = {
 		.recvfrom = mctp_op_recvfrom,
 		.close = mctp_op_close,
 	},
+	.bug_warn = mctp_bug_warn,
 };
 
 void mctp_ops_init(void) { }

--- a/src/mctp-ops.c
+++ b/src/mctp-ops.c
@@ -51,7 +51,7 @@ static int mctp_op_close(int sd)
 	return close(sd);
 }
 
-struct mctp_ops mctp_ops = {
+const struct mctp_ops mctp_ops = {
 	.mctp = {
 		.socket = mctp_op_mctp_socket,
 		.setsockopt = mctp_op_setsockopt,

--- a/src/mctp-ops.h
+++ b/src/mctp-ops.h
@@ -28,6 +28,6 @@ struct mctp_ops {
 	struct socket_ops nl;
 };
 
-extern struct mctp_ops mctp_ops;
+extern const struct mctp_ops mctp_ops;
 
 void mctp_ops_init(void);

--- a/src/mctp-ops.h
+++ b/src/mctp-ops.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <sys/socket.h>
+#include <stdarg.h>
 
 #define _GNU_SOURCE
 
@@ -26,6 +27,7 @@ struct socket_ops {
 struct mctp_ops {
 	struct socket_ops mctp;
 	struct socket_ops nl;
+	void (*bug_warn)(const char* fmt, va_list args);
 };
 
 extern const struct mctp_ops mctp_ops;

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -764,9 +764,6 @@ static int handle_control_resolve_endpoint_id(struct ctx *ctx,
 		resp_len = sizeof(*resp) + peer->phys.hwaddr_len;
 	}
 
-	printf("resp_len %zu ... 0x%02x 0x%02x\n", resp_len,
-		((uint8_t*)resp)[resp_len-2],
-		((uint8_t*)resp)[resp_len-1]);
 	return reply_message(ctx, sd, resp, resp_len, addr);
 }
 
@@ -990,7 +987,7 @@ static int cb_listen_monitor(sd_event_source *s, int sd, uint32_t revents,
 	}
 
 	if (ctx->verbose && any_error) {
-		printf("Error handling netlink update\n");
+		warnx("Error handling netlink update");
 		mctp_nl_changes_dump(ctx->nl, changes, num_changes);
 		mctp_nl_linkmap_dump(ctx->nl);
 	}
@@ -2280,7 +2277,7 @@ static void add_peer_neigh(struct peer *peer)
 
 	rc = mctp_nl_hwaddr_len_byindex(peer->ctx->nl, peer->phys.ifindex, &if_hwaddr_len);
 	if (rc) {
-		warnx("Missing neigh ifindex %d\n", peer->phys.ifindex);
+		warnx("Missing neigh ifindex %d", peer->phys.ifindex);
 		return;
 	}
 
@@ -2760,7 +2757,7 @@ static int bus_endpoint_get_prop(sd_bus *bus,
 	} else if (strcmp(property, "Connectivity") == 0) {
 		rc = sd_bus_message_append(reply, "s", peer->degraded ? "Degraded" : "Available");
 	} else {
-		printf("Unknown property '%s' for %s iface %s\n", property, path, interface);
+		warnx("Unknown property '%s' for %s iface %s", property, path, interface);
 		rc = -ENOENT;
 	}
 
@@ -2821,7 +2818,7 @@ static int bus_link_set_prop(sd_bus *bus,
 	int rc = -1;
 
 	if (strcmp(property, "Role") != 0) {
-		printf("Unknown property '%s' for %s iface %s\n", property, path, interface);
+		warnx("Unknown property '%s' for %s iface %s", property, path, interface);
 		rc = -ENOENT;
 		goto out;
 	}
@@ -2842,7 +2839,7 @@ static int bus_link_set_prop(sd_bus *bus,
 
 	rc = get_role(state, &role);
 	if (rc < 0) {
-		printf("Invalid property value '%s' for property '%s' from interface '%s' on object '%s'\n",
+		warnx("Invalid property value '%s' for property '%s' from interface '%s' on object '%s'",
 			state, property, interface, path);
 		rc = -EINVAL;
 		goto out;
@@ -2878,7 +2875,7 @@ static int bus_endpoint_set_prop(sd_bus *bus, const char *path,
 		} else if (strcmp(connectivity, "Degraded") == 0) {
 			peer->degraded = true;
 		} else {
-			printf("Invalid property value '%s' for property '%s' from interface '%s' on object '%s'\n",
+			warnx("Invalid property value '%s' for property '%s' from interface '%s' on object '%s'",
 				connectivity, property, interface, path);
 			rc = -EINVAL;
 			goto out;
@@ -2888,7 +2885,7 @@ static int bus_endpoint_set_prop(sd_bus *bus, const char *path,
 			rc = sd_bus_emit_properties_changed(bus, path, interface, "Connectivity", NULL);
 		}
 	} else {
-		printf("Unknown property '%s' in interface '%s' on object '%s'\n", property,
+		warnx("Unknown property '%s' in interface '%s' on object '%s'", property,
 			interface, path);
 		rc = -ENOENT;
 	}
@@ -3527,13 +3524,13 @@ static int add_interface(struct ctx *ctx, int ifindex)
 
 	uint32_t net = mctp_nl_net_byindex(ctx->nl, ifindex);
 	if (!net) {
-		warnx("Can't find link index %d\n", ifindex);
+		warnx("Can't find link index %d", ifindex);
 		return -ENOENT;
 	}
 
 	const char *ifname = mctp_nl_if_byindex(ctx->nl, ifindex);
 	if (!ifname) {
-		warnx("Can't find link name for index %d\n", ifindex);
+		warnx("Can't find link name for index %d", ifindex);
 		return -ENOENT;
 	}
 

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -3068,16 +3068,8 @@ static int emit_net_removed(struct ctx *ctx, struct net *net)
 
 static int emit_interface_removed(struct link *link)
 {
-	int ifindex = link->ifindex;
 	struct ctx *ctx = link->ctx;
-	const char* ifname = NULL;
 	int rc;
-
-	ifname = mctp_nl_if_byindex(ctx->nl, ifindex);
-	if (!ifname) {
-		warnx("BUG %s: no interface for ifindex %d", __func__, ifindex);
-		return -EPROTO;
-	}
 
 	if (link->ctx->verbose)
 		warnx("emitting interface remove: %s", link->path);
@@ -3252,6 +3244,9 @@ static int del_interface(struct link *link)
 	for (size_t i = 0; i < ctx->num_peers; i++) {
 		struct peer *p = ctx->peers[i];
 		if (p->state == REMOTE && p->phys.ifindex == ifindex) {
+			// Linux removes routes to deleted links, so no need to request removal.
+			p->have_neigh = false;
+			p->have_route = false;
 			remove_peer(p);
 		}
 	}

--- a/tests/mctp-ops-test.c
+++ b/tests/mctp-ops-test.c
@@ -216,6 +216,13 @@ static int mctp_op_close(int sd)
 	return close(sd);
 }
 
+static void mctp_bug_warn(const char* fmt, va_list args)
+{
+	vwarnx(fmt, args);
+	warnx("Aborting on bug in tests");
+	abort();
+}
+
 const struct mctp_ops mctp_ops = {
 	.mctp = {
 		.socket = mctp_op_mctp_socket,
@@ -233,6 +240,7 @@ const struct mctp_ops mctp_ops = {
 		.recvfrom = mctp_op_recvfrom,
 		.close = mctp_op_close,
 	},
+	.bug_warn = mctp_bug_warn,
 };
 
 void mctp_ops_init(void)

--- a/tests/mctp-ops-test.c
+++ b/tests/mctp-ops-test.c
@@ -216,7 +216,7 @@ static int mctp_op_close(int sd)
 	return close(sd);
 }
 
-struct mctp_ops mctp_ops = {
+const struct mctp_ops mctp_ops = {
 	.mctp = {
 		.socket = mctp_op_mctp_socket,
 		.setsockopt = mctp_op_setsockopt,

--- a/tests/mctpd/__init__.py
+++ b/tests/mctpd/__init__.py
@@ -199,7 +199,8 @@ class System:
             iface = route.iface
 
             neigh = self.lookup_neighbour(route.iface, addr.eid)
-            lladdr = neigh.lladdr
+            # if no neighbour, return an empty lladdr (eg mctpusb)
+            lladdr = neigh.lladdr if neigh else bytes()
 
         if iface is None or lladdr is None:
             return None

--- a/tests/mctpd/__init__.py
+++ b/tests/mctpd/__init__.py
@@ -143,7 +143,7 @@ class System:
     async def del_neighbour(self, neigh):
         neigh = self.lookup_neighbour(neigh.iface, neigh.eid)
         if not neigh:
-            raise NetlinkError(errno.EENOENT)
+            raise NetlinkError(errno.ENOENT)
         self.neighbours.remove(neigh)
         if self.nl:
             await self.nl.notify_delneigh(neigh)

--- a/tests/mctpd/__init__.py
+++ b/tests/mctpd/__init__.py
@@ -387,7 +387,7 @@ class ifinfmsg_mctp(rtnl.ifinfmsg.ifinfmsg):
             )
 
     class l2addr(netlink.nla_base):
-        fields = [('value', 'c')]
+        fields = [('value', 's')]
 
 class ifaddrmsg_mctp(rtnl.ifaddrmsg.ifaddrmsg):
     nla_map = (

--- a/tests/mctpd/__init__.py
+++ b/tests/mctpd/__init__.py
@@ -116,6 +116,16 @@ class System:
             await self.nl.notify_newlink(iface)
 
     async def del_interface(self, iface):
+        routes = list(filter(lambda x: x.iface == iface, self.routes))
+        for x in routes:
+            await self.del_route(x)
+        neighbours = list(filter(lambda x: x.iface == iface, self.neighbours))
+        for x in neighbours:
+            await self.del_neighbour(x)
+        addresses = list(filter(lambda x: x.iface == iface, self.addresses))
+        for x in addresses:
+            await self.del_address(x)
+
         self.interfaces.remove(iface)
         if self.nl:
             await self.nl.notify_dellink(iface)

--- a/tests/mctpd/__init__.py
+++ b/tests/mctpd/__init__.py
@@ -46,7 +46,7 @@ class System:
             self.name = name
             self.ifindex = ifindex
             self.net = net
-            self.lladdr = lladdr,
+            self.lladdr = lladdr
             self.min_mtu = min_mtu
             self.max_mtu = max_mtu
             self.mtu = max_mtu

--- a/tests/pytest.ini.in
+++ b/tests/pytest.ini.in
@@ -1,3 +1,6 @@
 [pytest]
 trio_mode = true
 testpaths = @testpaths@
+filterwarnings =
+    ignore:.*wait_readable:DeprecationWarning:asyncdbus
+    ignore:.*wait_writable:DeprecationWarning:asyncdbus


### PR DESCRIPTION
Previously the duplicate linkmaps would become inconsistent when interfaces were added/removed.
mctpd also attempted to remove a route for a deleted interface, even though the kernel would have already removed that route.

This PR also has a few cleanups encountered while adding a test. 

In the process of adding tests, I realised zero-length lladdr (for eg mctpusb) still adds neighbour entries. Those are not necessary, mctpd now omits adding those.

This should fix #55 and fix #73.