### PR TITLE
Allow passing config as a fixture

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -196,7 +196,7 @@ struct ctx {
 	sd_bus *bus;
 
 	// Configuration
-	const char *config_filename;
+	char *config_filename;
 
 	mctp_nl *nl;
 
@@ -3829,6 +3829,11 @@ static void setup_config_defaults(struct ctx *ctx)
 	ctx->default_role = ENDPOINT_ROLE_BUS_OWNER;
 }
 
+static void free_config(struct ctx *ctx)
+{
+	free(ctx->config_filename);
+}
+
 int main(int argc, char **argv)
 {
 	struct ctx ctxi = {0}, *ctx = &ctxi;
@@ -3900,6 +3905,7 @@ int main(int argc, char **argv)
 	free_links(ctx);
 	free_peers(ctx);
 	free_nets(ctx);
+	free_config(ctx);
 
 	mctp_nl_close(ctx->nl);
 

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -3573,7 +3573,7 @@ static int add_interface(struct ctx *ctx, int ifindex)
 		return -ENOENT;
 	}
 
-	struct link *link = malloc(sizeof(*link));
+	struct link *link = calloc(1, sizeof(*link));
 	if (!link)
 		return -ENOMEM;
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,12 @@ async def dbus():
         yield bus
 
 @pytest.fixture
-async def mctpd(nursery, dbus, sysnet):
-    m = fake_mctpd.MctpdWrapper(dbus, sysnet)
+def config():
+    return None
+
+@pytest.fixture
+async def mctpd(nursery, dbus, sysnet, config):
+    m = fake_mctpd.MctpdWrapper(dbus, sysnet, config = config)
     await m.start_mctpd(nursery)
     yield m
     res = await m.stop_mctpd()

--- a/tests/mctp_test_utils.py
+++ b/tests/mctp_test_utils.py
@@ -6,6 +6,13 @@ async def mctpd_mctp_iface_obj(dbus, iface):
         )
     return await obj.get_interface('au.com.codeconstruct.MCTP.BusOwner1')
 
+async def mctpd_mctp_iface_control_obj(dbus, iface):
+    obj = await dbus.get_proxy_object(
+            "au.com.codeconstruct.MCTP1",
+            "/au/com/codeconstruct/mctp1/interfaces/" + iface.name,
+        )
+    return await obj.get_interface("au.com.codeconstruct.MCTP.Interface1")
+
 async def mctpd_mctp_endpoint_obj(dbus, path, iface):
     obj = await dbus.get_proxy_object(
             'au.com.codeconstruct.MCTP1',

--- a/tests/test_mctpd_endpoint.py
+++ b/tests/test_mctpd_endpoint.py
@@ -1,0 +1,15 @@
+import pytest
+from mctp_test_utils import *
+from mctpd import *
+
+@pytest.fixture(name="config")
+def endpoint_config():
+    return """
+    mode = "endpoint"
+    """
+
+""" Test if mctpd is running as an endpoint """
+async def test_endpoint_role(dbus, mctpd):
+    obj = await mctpd_mctp_iface_control_obj(dbus, mctpd.system.interfaces[0])
+    role = await obj.get_role()
+    assert str(role) == "Endpoint"


### PR DESCRIPTION
This MR adds the capability to write tests for `mctpd` as an endpoint. This caught an uninitialized read bug on link data.