### PR TITLE
QOL changes for test runner

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,7 +124,7 @@ if tests
     # redirecting to a file. We can detect this if stdout is an terminal, and
     # disable TAP protocol.
     pytest = find_program('pytest')
-    script = '''export DBUS_STARTER_BUS_TYPE=user; if [ ! -t 1 ]; then PYTEST_FLAGS="--tap"; fi; @0@ $PYTEST_FLAGS'''.format(pytest.full_path())
+    script = '''export DBUS_STARTER_BUS_TYPE=user; if [ ! -t 1 ]; then PYTEST_FLAGS="--tap"; fi; @0@ $PYTEST_FLAGS $@'''.format(pytest.full_path())
     sh = find_program('sh')
     dbus_run_session = find_program('dbus-run-session')
 
@@ -140,7 +140,7 @@ if tests
 
     test('test-mctpd', dbus_run_session,
         depends: mctpd_test,
-        args: [ sh.full_path(), '-c', script ],
+        args: [ sh.full_path(), '-c', script, '--' ],
         protocol: 'tap',
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -118,8 +118,13 @@ if tests
     # Invoke pytest via a shell script under `dbus-run-session` so we can
     # override the sanitation of `DBUS_STARTER_BUS_TYPE`, ensuring `test-mctpd`
     # connects to the isolated session bus prepared by `dbus-run-session`.
+    #
+    # On newer meson versions, we can use meson test -C build --interactive
+    # to allow pytest to print output directly onto the terminal without
+    # redirecting to a file. We can detect this if stdout is an terminal, and
+    # disable TAP protocol.
     pytest = find_program('pytest')
-    script = 'export DBUS_STARTER_BUS_TYPE=user ; @0@ --tap'.format(pytest.full_path())
+    script = '''export DBUS_STARTER_BUS_TYPE=user; if [ ! -t 1 ]; then PYTEST_FLAGS="--tap"; fi; @0@ $PYTEST_FLAGS'''.format(pytest.full_path())
     sh = find_program('sh')
     dbus_run_session = find_program('dbus-run-session')
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,4 +3,4 @@ pyroute2==0.7.10
 pytest==8.3.2
 pytest-trio==0.8.0
 trio==0.26.2
-pytest-tap==3.4
+pytest-tap==3.5


### PR DESCRIPTION
This PR is a collection of small QOL changes to the test runner:

1. Make TAP output a tad more useful, with captured logs from `mctpd` subprocess.
2. Allow running without TAP by passing `--interactive` to `meson`.
3. Allow filtering tests (or passing arbitrary flags) to `pytest` via `--test-args`.

As a result, instead of

```
meson test -C obj
cd obj
dbus-run-session env DBUS_STARTER_BUS_TYPE=user pytest
cd ..
```

It can be now

```
meson test -C obj --interactive
```

and for filtering tests:

```
meson test -C obj --interactive --test-args="-k recov"
```