### PR TITLE
mctp-req: Make mctp-req a generic mctp client

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ executable('mctp',
 
 executable('mctp-req',
     sources: ['src/mctp-req.c'] + util_sources,
+    install: true
 )
 
 executable('mctp-echo',


### PR DESCRIPTION
Changes mctp-req to take and receive arbitrary mctp messages. Also makes a change to include it in the install by default.

Testing
--
send a simple get-eid command to an endpoint at eid 8:
```
mctp-req type 0 eid 8 data 0x80:0x02
0x00:0x02:0x00:0x08:0x01:0x00

mctp-req type 0 eid 9 data 0x80:0x02
0x00:0x02:0x00:0x09:0x01:0x00
```

testing default eid stays at 8
```
mctp-req type 0 data 0x80:0x02
0x00:0x02:0x00:0x08:0x01:0x00
```

testing corner cases for parsing
```
mctp-req data 0x80:0x02
mctp-req [eid <eid>] [net <net>] type <type> [ifindex <ifindex> lladdr <hwaddr>] data <data>
default eid 8 net 1

mctp-req type 0
mctp-req [eid <eid>] [net <net>] type <type> [ifindex <ifindex> lladdr <hwaddr>] data <data>
default eid 8 net 1

mctp-req type 0 data
mctp-req: extra argument data
mctp-req [eid <eid>] [net <net>] type <type> [ifindex <ifindex> lladdr <hwaddr>] data <data>
default eid 8 net 1

mctp-req data type 0
mctp-req: extra argument 0
mctp-req [eid <eid>] [net <net>] type <type> [ifindex <ifindex> lladdr <hwaddr>] data <data>
default eid 8 net 1
```