### PR TITLE
mctpd: improve handling for out-of-spec Set Endpoint ID responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    `au.com.codecontruct.MCTP.Interface1` interface, allowing link-to-network
    lookups
 
+5. mctpd: Better handling of strange cases of Set Endpoint ID responses,
+   where the reported endpoint EID may either be different from expected,
+   or invalid
+
 ### Changed
 
 1. tests are now run with address sanitizer enabled (-fsanitize=address)

--- a/src/mctp-util.c
+++ b/src/mctp-util.c
@@ -156,3 +156,8 @@ char* bytes_to_uuid(const uint8_t u[16])
 		u[8], u[9], u[10], u[11], u[12], u[13], u[14], u[15]);
 	return buf;
 }
+
+bool mctp_eid_is_valid_unicast(mctp_eid_t eid)
+{
+	return eid >= 8 && eid < 0xff;
+}

--- a/src/mctp-util.h
+++ b/src/mctp-util.h
@@ -1,4 +1,7 @@
+#include <stdbool.h>
 #include <stdint.h>
+
+#include "mctp.h"
 
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define min(a, b) ((a) < (b) ? (a) : (b))
@@ -13,3 +16,4 @@ int parse_uint32(const char *str, uint32_t *out);
 int parse_int32(const char *str, int32_t *out);
 /* Returns a malloced pointer */
 char* bytes_to_uuid(const uint8_t u[16]);
+bool mctp_eid_is_valid_unicast(mctp_eid_t eid);


### PR DESCRIPTION
We may have endpoints reporting strange EID values in their set endpoint ID response, even when reporting that the assignement was accepted. Particularly, if the EID is in the invalid range, we will still attempt to add neighour and route entries for this invalid EID.

We still want to accommodate valid IDs that were not the same as the one assigned, but ensure the EID is valid before processing.