### PR TITLE
mctp: neigh: Only print 0x prefix for 1-byte addrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 1. tests are now run with address sanitizer enabled (-fsanitize=address)
 
+2. `mctp neigh` hardware address formatting is improved.
+
 ### Removed
 
 1. mctpd: Test mode (`-N`) has been removed, as we have a more comprehensive

--- a/src/mctp.c
+++ b/src/mctp.c
@@ -311,13 +311,16 @@ static int display_neighbour(struct ctx *ctx, void *p, size_t len)
 	eid = 0;
 	mctp_get_rtnlmsg_attr_u8(NDA_DST, rta, rta_len, &eid);
 	lladdr = mctp_get_rtnlmsg_attr(NDA_LLADDR, rta, rta_len, &lladdr_len);
-	printf("eid %d net %u dev %s lladdr 0x", eid,
+	printf("eid %d net %u dev %s lladdr ", eid,
 	       mctp_nl_net_byindex(ctx->nl, msg->ndm_ifindex),
 	       mctp_nl_if_byindex(ctx->nl, msg->ndm_ifindex));
+	if (lladdr_len == 1) {
+		printf("0x");
+	}
 	if (lladdr && lladdr_len)
 		print_hex_addr(lladdr, lladdr_len);
 	else
-		printf("(no-addr)");
+		printf("none");
 	printf("\n");
 	return 0;
 }


### PR DESCRIPTION
"none" is printed instead of "(no-addr)" for no-address devices.

This matches the previous change to "mctp addr" in
https://github.com/CodeConstruct/mctp/commit/c519bba4ca238d1c7f83bfc506d6dfa7c9baca98 ("mctp: Improve formatting of interface addresses")