### PR TITLE
Add support for gateway & range routing operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 7. `mctp` now supports gateway routes
 
+8. `mctp` route can add & delete range routes, using a <min>-<max> range format
+
 ### Changed
 
 1. tests are now run with address sanitizer enabled (-fsanitize=address)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 6. New debug/test tool, `mctp-bench`, for performing basic requests to MCTP
    endpoints, and printing their responses
 
+7. `mctp` now supports gateway routes
+
 ### Changed
 
 1. tests are now run with address sanitizer enabled (-fsanitize=address)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Use `mctp help` for the list of available commands:
     mctp route
     mctp route show [net <network>]
     mctp route add <eid> via <dev> [mtu <mtu>]
+    mctp route add <eid> gw <eid> [net <net>] [mtu <mtu>]
     mctp route del <eid> via <dev>
+    mctp route del <eid> gw <eid> [net <net>]
 
     mctp neigh
     mctp neigh show [dev <network>]

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Use `mctp help` for the list of available commands:
 
     mctp route
     mctp route show [net <network>]
-    mctp route add <eid> via <dev> [mtu <mtu>]
-    mctp route add <eid> gw <eid> [net <net>] [mtu <mtu>]
-    mctp route del <eid> via <dev>
-    mctp route del <eid> gw <eid> [net <net>]
+    mctp route add <eid>[-<eid>] via <dev> [mtu <mtu>]
+    mctp route add <eid>[-<eid>] gw <eid> [net <net>] [mtu <mtu>]
+    mctp route del <eid>[-<eid>] via <dev>
+    mctp route del <eid>[-<eid>] gw <eid> [net <net>]
 
     mctp neigh
     mctp neigh show [dev <network>]

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,10 @@ conf.set10('HAVE_LINUX_MCTP_H',
     cc.has_header('linux/mctp.h'),
     description: 'Is linux/mctp.h available?'
 )
+conf.set10('HAVE_STRUCT_MCTP_FQ_ADDR',
+    cc.has_type('struct mctp_fq_addr', prefix: '#include <linux/mctp.h>'),
+    description: 'Is struct mctp_fq_addr available?'
+)
 conf.set10('MCTPD_RECOVER_NIL_UUID',
     get_option('unsafe-recover-nil-uuid'),
     description: 'Consider a nil UUID to be valid for endpoint recovery purposes',

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -443,6 +443,23 @@ bool mctp_get_rtnlmsg_attr_u8(int rta_type, struct rtattr *rta, size_t len,
 	return false;
 }
 
+bool mctp_get_rtnlmsg_fq_addr(int rta_type, struct rtattr *rta, size_t len,
+			      struct mctp_fq_addr *addr)
+{
+	size_t plen;
+	uint8_t *p = mctp_get_rtnlmsg_attr(rta_type, rta, len, &plen);
+	if (p) {
+		if (plen == sizeof(*addr)) {
+			memcpy(addr, p, plen);
+			return true;
+		} else {
+			warnx("Unexpected attribute length %zu for mctp_fq_addr",
+			      plen);
+		}
+	}
+	return false;
+}
+
 /* Returns the space used */
 size_t mctp_put_rtnlmsg_attr(struct rtattr **prta, size_t *rta_len,
 			     unsigned short type, const void *value,

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -109,8 +109,9 @@ int mctp_nl_addr_del(struct mctp_nl *nl, uint8_t eid, int ifindex);
 
 /* MCTP route helper */
 int mctp_nl_route_add(struct mctp_nl *nl, uint8_t eid, int ifindex,
-		      uint32_t mtu);
-int mctp_nl_route_del(struct mctp_nl *nl, uint8_t eid, int ifindex);
+		      const struct mctp_fq_addr *gw, uint32_t mtu);
+int mctp_nl_route_del(struct mctp_nl *nl, uint8_t eid, int ifindex,
+		      const struct mctp_fq_addr *gw);
 
 /* Helpers */
 

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -38,6 +38,13 @@ struct mctp_nl_change {
 };
 typedef struct mctp_nl_change mctp_nl_change;
 
+#if !HAVE_STRUCT_MCTP_FQ_ADDR
+struct mctp_fq_addr {
+	unsigned int net;
+	mctp_eid_t eid;
+};
+#endif
+
 /* Allocates the structure, connects to netlink, and populates
    the list of interfaces */
 // verbose flag controls dumping error response packets
@@ -113,6 +120,8 @@ bool mctp_get_rtnlmsg_attr_u32(int rta_type, struct rtattr *rta, size_t len,
 			       uint32_t *ret_value);
 bool mctp_get_rtnlmsg_attr_u8(int rta_type, struct rtattr *rta, size_t len,
 			      uint8_t *ret_value);
+bool mctp_get_rtnlmsg_fq_addr(int rta_type, struct rtattr *rta, size_t len,
+			      struct mctp_fq_addr *addr);
 /* Returns the space used */
 size_t mctp_put_rtnlmsg_attr(struct rtattr **prta, size_t *rta_len,
 			     unsigned short type, const void *value,

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -108,10 +108,10 @@ int mctp_nl_addr_add(struct mctp_nl *nl, uint8_t eid, int ifindex);
 int mctp_nl_addr_del(struct mctp_nl *nl, uint8_t eid, int ifindex);
 
 /* MCTP route helper */
-int mctp_nl_route_add(struct mctp_nl *nl, uint8_t eid, int ifindex,
-		      const struct mctp_fq_addr *gw, uint32_t mtu);
-int mctp_nl_route_del(struct mctp_nl *nl, uint8_t eid, int ifindex,
-		      const struct mctp_fq_addr *gw);
+int mctp_nl_route_add(struct mctp_nl *nl, uint8_t eid, unsigned int extent,
+		      int ifindex, const struct mctp_fq_addr *gw, uint32_t mtu);
+int mctp_nl_route_del(struct mctp_nl *nl, uint8_t eid, unsigned int extent,
+		      int ifindex, const struct mctp_fq_addr *gw);
 
 /* Helpers */
 

--- a/src/mctp-util.c
+++ b/src/mctp-util.c
@@ -135,6 +135,20 @@ int parse_int32(const char *str, int32_t *out)
 	return 0;
 }
 
+int parse_eid(const char *str, mctp_eid_t *eid)
+{
+	uint32_t tmp;
+
+	if (parse_uint32(str, &tmp) < 0)
+		return -1;
+
+	if (tmp > 0xff)
+		return -1;
+
+	*eid = tmp;
+	return 0;
+}
+
 /* Returns a malloced pointer */
 char *bytes_to_uuid(const uint8_t u[16])
 {

--- a/src/mctp-util.h
+++ b/src/mctp-util.h
@@ -15,6 +15,7 @@ int write_hex_addr(const uint8_t *data, size_t len, char *dest,
 int parse_hex_addr(const char *in, uint8_t *out, size_t *out_len);
 int parse_uint32(const char *str, uint32_t *out);
 int parse_int32(const char *str, int32_t *out);
+int parse_eid(const char *str, mctp_eid_t *eid);
 /* Returns a malloced pointer */
 char *bytes_to_uuid(const uint8_t u[16]);
 bool mctp_eid_is_valid_unicast(mctp_eid_t eid);

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -1601,7 +1601,7 @@ static int peer_set_mtu(struct ctx *ctx, struct peer *peer, uint32_t mtu)
 		return -EPROTO;
 	}
 
-	rc = mctp_nl_route_del(ctx->nl, peer->eid, peer->phys.ifindex);
+	rc = mctp_nl_route_del(ctx->nl, peer->eid, peer->phys.ifindex, NULL);
 	if (rc < 0 && rc != -ENOENT) {
 		warnx("%s, Failed removing existing route for eid %d %s",
 		      __func__, peer->phys.ifindex,
@@ -1609,7 +1609,8 @@ static int peer_set_mtu(struct ctx *ctx, struct peer *peer, uint32_t mtu)
 		// Continue regardless, route_add will likely fail with EEXIST
 	}
 
-	rc = mctp_nl_route_add(ctx->nl, peer->eid, peer->phys.ifindex, mtu);
+	rc = mctp_nl_route_add(ctx->nl, peer->eid, peer->phys.ifindex, NULL,
+			       mtu);
 	if (rc >= 0) {
 		peer->mtu = mtu;
 	}
@@ -2324,10 +2325,10 @@ static int peer_route_update(struct peer *peer, uint16_t type)
 
 	if (type == RTM_NEWROUTE) {
 		return mctp_nl_route_add(peer->ctx->nl, peer->eid,
-					 peer->phys.ifindex, peer->mtu);
+					 peer->phys.ifindex, NULL, peer->mtu);
 	} else if (type == RTM_DELROUTE) {
 		return mctp_nl_route_del(peer->ctx->nl, peer->eid,
-					 peer->phys.ifindex);
+					 peer->phys.ifindex, NULL);
 	}
 
 	bug_warn("%s: bad type %d", __func__, type);

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -1601,7 +1601,7 @@ static int peer_set_mtu(struct ctx *ctx, struct peer *peer, uint32_t mtu)
 		return -EPROTO;
 	}
 
-	rc = mctp_nl_route_del(ctx->nl, peer->eid, peer->phys.ifindex, NULL);
+	rc = mctp_nl_route_del(ctx->nl, peer->eid, 0, peer->phys.ifindex, NULL);
 	if (rc < 0 && rc != -ENOENT) {
 		warnx("%s, Failed removing existing route for eid %d %s",
 		      __func__, peer->phys.ifindex,
@@ -1609,7 +1609,7 @@ static int peer_set_mtu(struct ctx *ctx, struct peer *peer, uint32_t mtu)
 		// Continue regardless, route_add will likely fail with EEXIST
 	}
 
-	rc = mctp_nl_route_add(ctx->nl, peer->eid, peer->phys.ifindex, NULL,
+	rc = mctp_nl_route_add(ctx->nl, peer->eid, 0, peer->phys.ifindex, NULL,
 			       mtu);
 	if (rc >= 0) {
 		peer->mtu = mtu;
@@ -2324,10 +2324,10 @@ static int peer_route_update(struct peer *peer, uint16_t type)
 	}
 
 	if (type == RTM_NEWROUTE) {
-		return mctp_nl_route_add(peer->ctx->nl, peer->eid,
+		return mctp_nl_route_add(peer->ctx->nl, peer->eid, 0,
 					 peer->phys.ifindex, NULL, peer->mtu);
 	} else if (type == RTM_DELROUTE) {
-		return mctp_nl_route_del(peer->ctx->nl, peer->eid,
+		return mctp_nl_route_del(peer->ctx->nl, peer->eid, 0,
 					 peer->phys.ifindex, NULL);
 	}
 


### PR DESCRIPTION
Now that the gateway support has hit net-next (https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=ad39c12fcee34b8980a80ad5c803bca9906fbd4e), we can add the userspace components that rely on the new rtnetlink interface