### PR TITLE
Handle MCTP interface rename events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 9. In-tree tests now include coverage for the `mctp` utility
 
+10. `mctpd` now handles interface name changes, updating dbus objects to
+    reflect new interface names.
+
 ### Changed
 
 1. tests are now run with address sanitizer enabled (-fsanitize=address)

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -301,6 +301,16 @@ static void fill_link_changes(const struct linkmap_entry *old, size_t old_count,
 				ch->old_up = oe->up;
 				ch->link_userdata = oe->userdata;
 			}
+
+			if (strncmp(oe->ifname, ne->ifname,
+				    sizeof(oe->ifname))) {
+				ch = push_change(changes, &siz);
+				ch->op = MCTP_NL_CHANGE_NAME;
+				ch->ifindex = ne->ifindex;
+				memcpy(ch->old_name, ne->ifname,
+				       sizeof(ch->old_name));
+				ch->link_userdata = oe->userdata;
+			}
 			o++;
 			n++;
 		} else if (!oe || (ne && ne->ifindex < oe->ifindex)) {
@@ -343,9 +353,9 @@ void mctp_nl_changes_dump(mctp_nl *nl, mctp_nl_change *changes,
 		if (!ifname)
 			ifname = "deleted";
 		fprintf(stderr,
-			"%3zd %-12s ifindex %3d (%-20s) eid %3d old_net %4d old_up %d\n",
+			"%3zd %-12s ifindex %3d (%-20s) eid %3d old_net %4d old_up %d old name %s\n",
 			i, ops[ch->op], ch->ifindex, ifname, ch->eid,
-			ch->old_net, ch->old_up);
+			ch->old_net, ch->old_up, ch->old_name);
 	}
 }
 

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -202,11 +202,16 @@ err:
 
 mctp_nl_change *push_change(mctp_nl_change **changes, size_t *psize)
 {
+	struct mctp_nl_change *ch;
 	size_t siz = *psize;
+
 	siz++;
 	*changes = realloc(*changes, siz * sizeof(**changes));
 	*psize = siz;
-	return &(*changes)[siz - 1];
+	ch = &(*changes)[siz - 1];
+	memset(ch, 0, sizeof(*ch));
+
+	return ch;
 }
 
 static void fill_eid_changes(const struct linkmap_entry *oe,

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -17,6 +17,7 @@ struct mctp_nl_change {
 		MCTP_NL_DEL_LINK,
 		MCTP_NL_CHANGE_NET,
 		MCTP_NL_CHANGE_UP,
+		MCTP_NL_CHANGE_NAME,
 		MCTP_NL_ADD_EID,
 		MCTP_NL_DEL_EID,
 	} op;
@@ -32,8 +33,11 @@ struct mctp_nl_change {
 	// Filled for CHANGE_UP
 	bool old_up;
 
+	// Filled for CHANGE_NAME
+	char old_name[IFNAMSIZ + 1];
+
 	// If userdata is present on the link, it is passed here. Populated for
-	// link change events (DEL_LINK, CHANGE_NET, CHANGE_UP).
+	// link change events (DEL_LINK, CHANGE_NET, CHANGE_UP, CHANGE_NAME).
 	void *link_userdata;
 };
 typedef struct mctp_nl_change mctp_nl_change;


### PR DESCRIPTION
Interface renames may happen as part of persistent net name rules, so we should handle them in mctpd.

This series checks for name changes in the RTM_GETLINK dumps, and creates `mctp_nl_change` data to represent these. We then add handlers for these events in mctpd, and update the dbus objects to suit.