### PR TITLE
mctpd: Fix IID of MCTP Control response message

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -64,7 +64,7 @@ static mctp_eid_t eid_alloc_max = 0xfe;
 static size_t MAX_PEER_SIZE = 1000000;
 
 static const uint8_t RQDI_REQ = 1 << 7;
-static const uint8_t RQDI_RESP = 0x0;
+static const uint8_t RQDI_RESP_MASK = 0x7f;
 static const uint8_t RQDI_IID_MASK = 0x1f;
 
 struct dest_phys {
@@ -645,7 +645,7 @@ static int handle_control_set_endpoint_id(struct ctx *ctx, int sd,
 	req = (void *)buf;
 
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 	resp->completion_code = 0;
 	resp->status = 0x01 << 4; // Already assigned, TODO
 	resp->eid_set = local_addr(ctx, addr->smctp_ifindex);
@@ -696,7 +696,7 @@ handle_control_get_version_support(struct ctx *ctx, int sd,
 	}
 
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 	return reply_message(ctx, sd, resp, resp_len, addr);
 }
 
@@ -715,7 +715,7 @@ static int handle_control_get_endpoint_id(struct ctx *ctx, int sd,
 
 	req = (void *)buf;
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 
 	resp->eid = local_addr(ctx, addr->smctp_ifindex);
 	if (ctx->default_role == ENDPOINT_ROLE_BUS_OWNER)
@@ -744,7 +744,7 @@ handle_control_get_endpoint_uuid(struct ctx *ctx, int sd,
 
 	req = (void *)buf;
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 	memcpy(resp->uuid, ctx->uuid, sizeof(resp->uuid));
 	return reply_message(ctx, sd, resp, sizeof(*resp), addr);
 }
@@ -767,7 +767,7 @@ static int handle_control_get_message_type_support(
 	req = (void *)buf;
 	resp = (void *)resp_buf;
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 
 	// Only control messages supported
 	resp->msg_type_count = 1;
@@ -797,7 +797,7 @@ handle_control_resolve_endpoint_id(struct ctx *ctx, int sd,
 	resp = (void *)resp_buf;
 	memset(resp, 0x0, sizeof(*resp));
 	resp->ctrl_hdr.command_code = req->ctrl_hdr.command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 
 	peer = find_peer_by_addr(ctx, req->eid, addr->smctp_base.smctp_network);
 	if (!peer) {
@@ -832,7 +832,7 @@ static int handle_control_unsupported(struct ctx *ctx, int sd,
 
 	req = (void *)buf;
 	resp->ctrl_hdr.command_code = req->command_code;
-	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP;
+	resp->ctrl_hdr.rq_dgram_inst = RQDI_RESP_MASK & req->ctrl_hdr.rq_dgram_inst;
 	resp->completion_code = MCTP_CTRL_CC_ERROR_UNSUPPORTED_CMD;
 	return reply_message(ctx, sd, resp, sizeof(*resp), addr);
 }


### PR DESCRIPTION
Fix incorrect IID of an MCTP Response message and it should match to the IID of an MCTP Request message.