### PR TITLE
mctpd: fix endpoint peer iteration on interface delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## Fixed
+
+1. mctpd: fixed an issue where endpoints may persist when their dependent
+   interface is deleted
+
 ## [2.2] - 2025-07-28
 
 ### Fixed


### PR DESCRIPTION
We currently scan through ctx->peers while deleting an interface, removing pertinent peers.

However, the removal will shift the indices (and possibly realloc ctx->peers). So, adjust our handling of the loop counter to suit.

Fixes: https://github.com/CodeConstruct/mctp/issues/97
Reported-by: Faizan Ali <faizana@nvidia.com>