### PR TITLE
mctpd: Add bus-owner configuration, implement dynamic EID setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 1. `mctp-bench` now supports a "request receive" mode, where
    `mctp-bench recv eid <...>` sends a command to start the benchmark session.
 
+2. `mctpd` now supports a bus-owner configuration section
+
 ## [2.2] - 2025-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2. `mctpd` now supports a bus-owner configuration section
 
+3. Added documentation for `mctpd.conf` settings
+
 ## [2.2] - 2025-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 3. Added documentation for `mctpd.conf` settings
 
+4. `mctpd`'s dynamic EID range is now configurable
+
 ## [2.2] - 2025-07-28
 
 ### Fixed

--- a/conf/mctpd.conf
+++ b/conf/mctpd.conf
@@ -11,5 +11,8 @@ message_timeout_ms = 30
 
 # bus-owner configuration
 [bus-owner]
-max_pool_size = 15
 
+# dynamic EID range: a 2-element array of min and max (inclusive) EID values.
+dynamic_eid_range = [8, 254]
+
+max_pool_size = 15

--- a/conf/mctpd.conf
+++ b/conf/mctpd.conf
@@ -8,3 +8,8 @@ message_timeout_ms = 30
 # Specify a UUID: not generally required - mctpd will query the system UUID
 # where available.
 # uuid = "21f0f554-7f7c-4211-9ca1-6d0f000ea9e7"
+
+# bus-owner configuration
+[bus-owner]
+max_pool_size = 15
+

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -214,3 +214,73 @@ busctl call au.com.codeconstruct.MCTP1 \
 ### `.Remove`
 
 Removes the MCTP endpoint from `mctpd`, and deletes routes and neighbour entries.
+
+## Configuration
+
+`mctpd` reads configuration data from a TOML file, typically `/etc/mctpd.conf`.
+An alternative configuration file can be specified using the `--config`
+command-line option.
+
+The configuration file has a global section, plus function-specific sections.
+
+### Global settings
+
+These apply to all modes of `mctpd` operation. One top-level setting is defined:
+
+#### `mode`: mctpd mode of operation
+
+* type: string enum: `bus-owner` or `endpoint`
+* default: `bus-owner`
+
+This sets the overall mode of `mctpd`, either as a Bus Owner (`mode =
+"bus-owner"`) or Endpoint (`mode = "endpoint"`). In bus owner mode, mctpd will
+assume responsibility for allocating addresses to other endpoints. In endpoint
+mode, mctpd will not allocate addresses, but instead accept allocations from an
+external bus owner.
+
+### `[mctp]` section
+
+This section affects MCTP protocol behaviour, and any common values used for
+both bus-owner and endpoint modes.
+
+#### `message_timeout_ms`: global MCTP message timeout
+
+* type: integer, in milliseconds
+* default: 250
+
+This sets the timeout for outgoing request messages. A message will be
+considered lost if no response is received within this timeout.
+
+Long timeouts may degrade `mctpd` performance, as we typically wait for
+operations synchronously.
+
+#### `uuid`: endpoint UUID value
+
+* type: string, UUID format
+* default: queried from system
+
+This sets the UUID used to identify this endpoint to peers, as returned in the
+MCTP "Get Endpoint UUID" command.
+
+This is not typically needed; if no `uuid` configuration is specified, `mctpd`
+will use the system-wide UUID value, which has generally correct semantics
+for the MCTP endpoint UUID.
+
+The UUID should be formatted as a RFC 4122 UUID string, for example:
+
+```
+uuid = "21f0f554-7f7c-4211-9ca1-6d0f000ea9e7"
+```
+
+#### `[bus-owner]` section
+
+This section affects behaviour when `mctpd` is running in bus owner mode
+
+#### `max_pool_size`: Maximum peer allocation pool size
+
+* type: integer
+* default: 15
+
+This setting determines the maximum EID pool size that a bridge peer may request
+via their Set Endpoint ID response. Requests larger than this size will be
+truncated.

--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -276,6 +276,20 @@ uuid = "21f0f554-7f7c-4211-9ca1-6d0f000ea9e7"
 
 This section affects behaviour when `mctpd` is running in bus owner mode
 
+#### `dynamic_eid_range`: Range for dynamic EID allocations
+
+* type: array of integers, 2 elements
+* default: `[ 8, 254 ]`
+
+This setting specifies the range of dynamic EIDs that `mctpd` will allocate
+new peers' EIDs from. Values are inclusive.
+
+Local interface EIDs and statically-allocated EIDs may fall outside this range;
+it is only used when a peer needs a new dynamic address.
+
+The default value makes the entire MCTP EID address space available for dynamic
+allocations.
+
 #### `max_pool_size`: Maximum peer allocation pool size
 
 * type: integer


### PR DESCRIPTION
This series adds a new section to `mctpd.conf`, allowing bus-owner configuration. We use this to implement the requested dynamic EID ranges control in #94 .

```toml
[bus-owner]
dynamic_eid_range = [50, 60]
```

I'm pulling-in @faizana-nvidia's support for the general `[bus-owner]` section, including the pool-size config, as we will need that in the bridge functionality later anyway.

Fixes: #94 