### PR TITLE
meson: mctpd_test is only required for mctpd-enabled builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,8 @@ mctp_test = executable('test-mctp',
     include_directories:  include_directories('src'),
 )
 
+test_deps = [mctp_test]
+
 executable('mctp-req',
     sources: ['src/mctp-req.c'] + util_sources,
 )
@@ -97,6 +99,7 @@ if libsystemd.found()
         include_directories:  include_directories('src'),
         dependencies: [libsystemd, toml_dep],
     )
+    test_deps += mctpd_test
 endif
 
 tests = get_option('tests')
@@ -153,7 +156,7 @@ if tests
     )
 
     test('test-mctpd', dbus_run_session,
-        depends: [mctpd_test, mctp_test],
+        depends: [test_deps],
         args: [ sh.full_path(), '-c', script, '--' ],
         protocol: 'tap',
     )


### PR DESCRIPTION
If we're building without mctpd (ie, no libsystemd), then we won't have a mctpd_test variable defined, so meson will fail:

    meson.build:156:18: ERROR: Unknown variable "mctpd_test".

This builds the test dependencies according to what is enabled instead.

Fixes: https://github.com/CodeConstruct/mctp/issues/102