### PR TITLE
mctp: don't include linux/mctp.h directly

### DIFF
--- a/src/mctp-control-spec.h
+++ b/src/mctp-control-spec.h
@@ -5,7 +5,8 @@
 
 #include <assert.h>
 #include <stdint.h>
-#include <linux/mctp.h>
+
+#include "mctp.h"
 
 /*
  * Helper structs and functions for MCTP control messages.

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <linux/if.h>
 #include <linux/rtnetlink.h>
 
 #include "mctp.h"


### PR DESCRIPTION
Commit e35f4a5 ("mctpd: avoid bitfield & implicit enum values in wire format") introduced a #include <linux/mctp.h> for mctp_eid_t. However, we want the ability to fall-back to the in-tree definitions, so use the internal mctp.h instead. This will use mctp.h if available.

Fixes: https://github.com/CodeConstruct/mctp/issues/103
Fixes: e35f4a5 ("mctpd: avoid bitfield & implicit enum values in wire format")