### PR TITLE
Minor warning fixes

### DIFF
--- a/src/mctp-bench.c
+++ b/src/mctp-bench.c
@@ -683,7 +683,10 @@ static int command(mctp_eid_t eid, int net, enum command command,
 	req->magic = COMMAND_MAGIC;
 	req->version = COMMAND_VERSION;
 	req->command = command;
-	getrandom(&req->iid, sizeof(req->iid), 0);
+	/* on a recent kernel (ie., any with MCTP support), getrandom is
+	 * infallible with <=256-byte lengths
+	 */
+	(void)getrandom(&req->iid, sizeof(req->iid), 0);
 	memcpy(req->body, body, body_len);
 
 	rc = sendto(sd, req, req_len, 0, (struct sockaddr *)&addr,

--- a/src/mctp-client.c
+++ b/src/mctp-client.c
@@ -209,13 +209,11 @@ static int find_data(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	int ctr, data_idx, net = MCTP_NET_ANY;
+	unsigned int net = MCTP_NET_ANY;
 	bool valid_eid, valid_type;
 	struct data_t send_data;
-	char *tag, *endp, *val;
-	unsigned long int tmp;
+	int type, ctr, data_idx;
 	mctp_eid_t eid;
-	int type;
 
 	data_idx = find_data(argc, argv);
 	if (data_idx < 0) {
@@ -235,33 +233,29 @@ int main(int argc, char **argv)
 	valid_type = false;
 
 	for (ctr = 1; ctr < argc; ctr += 2) {
-		bool valid_parse;
+		char *tag, *val;
+		int rc;
 
 		tag = argv[ctr];
 		val = argv[ctr + 1];
-		tmp = strtoul(val, &endp, 0);
-		valid_parse = endp != val;
+
 		if (!strcmp(tag, "eid")) {
-			if (tmp > 0xff)
+			rc = parse_eid(val, &eid);
+			if (rc)
 				errx(EXIT_FAILURE, "invalid eid: %s", val);
-			eid = tmp;
 			valid_eid = true;
 		} else if (!strcmp(tag, "net")) {
-			if (net > 0xff)
+			rc = parse_uint32(val, &net);
+			if (rc)
 				errx(EXIT_FAILURE, "invalid net: %s", val);
-			net = tmp;
 		} else if (!strcmp(tag, "type")) {
 			type = do_type_lookup(val);
 			if (type < 0 || type > 0xff)
 				errx(EXIT_FAILURE, "invalid type: %s", val);
-
-			valid_parse = true;
 			valid_type = true;
+
 		} else
 			errx(EXIT_FAILURE, "invalid tag: %s", tag);
-
-		if (!valid_parse)
-			errx(EXIT_FAILURE, "invalid argument: %s", val);
 	}
 
 	if (!valid_eid || !valid_type) {

--- a/src/mctp-client.c
+++ b/src/mctp-client.c
@@ -209,8 +209,8 @@ static int find_data(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-	bool valid_parse, valid_eid, valid_type;
 	int ctr, data_idx, net = MCTP_NET_ANY;
+	bool valid_eid, valid_type;
 	struct data_t send_data;
 	char *tag, *endp, *val;
 	unsigned long int tmp;
@@ -235,6 +235,8 @@ int main(int argc, char **argv)
 	valid_type = false;
 
 	for (ctr = 1; ctr < argc; ctr += 2) {
+		bool valid_parse;
+
 		tag = argv[ctr];
 		val = argv[ctr + 1];
 		tmp = strtoul(val, &endp, 0);
@@ -257,9 +259,12 @@ int main(int argc, char **argv)
 			valid_type = true;
 		} else
 			errx(EXIT_FAILURE, "invalid tag: %s", tag);
+
+		if (!valid_parse)
+			errx(EXIT_FAILURE, "invalid argument: %s", val);
 	}
 
-	if (!valid_parse || !valid_eid || !valid_type) {
+	if (!valid_eid || !valid_type) {
 		print_usage();
 		return EXIT_FAILURE;
 	}

--- a/src/mctp-client.c
+++ b/src/mctp-client.c
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
 			valid_type = true;
 
 		} else
-			errx(EXIT_FAILURE, "invalid tag: %s", tag);
+			errx(EXIT_FAILURE, "invalid argument: %s", tag);
 	}
 
 	if (!valid_eid || !valid_type) {


### PR DESCRIPTION
Address a couple of warnings on a `x86_64-buildroot-linux-gnu` target.