### PR TITLE
netlink: Fix NL_OP_COUNT definition, add debug for CHANGE_NAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 2. Header compatibility fixes for environments without a recent linux/mctp.h
 
+3. Fixed a potential array overrun when dumping netlink change events
+
 ## Added
 
 1. `mctp-bench` now supports a "request receive" mode, where

--- a/src/mctp-netlink.c
+++ b/src/mctp-netlink.c
@@ -345,8 +345,8 @@ void mctp_nl_changes_dump(mctp_nl *nl, mctp_nl_change *changes,
 			  size_t num_changes)
 {
 	const char *ops[MCTP_NL_OP_COUNT] = {
-		"ADD_LINK",  "DEL_LINK", "CHANGE_NET",
-		"CHANGE_UP", "ADD_EID",	 "DEL_EID",
+		"ADD_LINK",    "DEL_LINK", "CHANGE_NET", "CHANGE_UP",
+		"CHANGE_NAME", "ADD_EID",  "DEL_EID",
 	};
 
 	fprintf(stderr, "%zu changes:\n", num_changes);

--- a/src/mctp-netlink.h
+++ b/src/mctp-netlink.h
@@ -13,7 +13,7 @@ struct mctp_nl;
 typedef struct mctp_nl mctp_nl;
 
 struct mctp_nl_change {
-#define MCTP_NL_OP_COUNT 6
+#define MCTP_NL_OP_COUNT __MCTP_NL_OP_MAX
 	enum {
 		MCTP_NL_ADD_LINK,
 		MCTP_NL_DEL_LINK,
@@ -22,6 +22,7 @@ struct mctp_nl_change {
 		MCTP_NL_CHANGE_NAME,
 		MCTP_NL_ADD_EID,
 		MCTP_NL_DEL_EID,
+		__MCTP_NL_OP_MAX,
 	} op;
 
 	int ifindex;

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -1361,6 +1361,8 @@ static int cb_listen_monitor(sd_event_source *s, int sd, uint32_t revents,
 			// 'up' state is currently unused
 			break;
 		}
+		default:
+			bug_warn("Unhandled netlink change type %d", c->op);
 		}
 	}
 


### PR DESCRIPTION
Commit 1b6c367 ("mctp-netlink: add MCTP_NL_CHANGE_NAME event") did not update the COUNT definition, so causing a potential array index overrun on change dump.

Instead of hard-coding, use the enum itself for the count value, and add a dump string for the new CHANGE_NAME event type.

Fixes: 1b6c367 ("mctp-netlink: add MCTP_NL_CHANGE_NAME event")
Fixes: https://github.com/CodeConstruct/mctp/issues/120
Reported-by: Nidhin MS <nidhin.ms@intel.com>