### PR TITLE
mctpd: replace sd-event timers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,11 +60,13 @@ toml_dep = declare_dependency(
 executable('mctp',
     sources: ['src/mctp.c'] + netlink_sources + util_sources + ops_sources,
     install: true,
+    c_args: ['-DHAVE_LIBSYSTEMD=0'],
 )
 
 mctp_test = executable('test-mctp',
     sources: ['src/mctp.c'] + netlink_sources + util_sources + test_ops_sources,
     include_directories:  include_directories('src'),
+    c_args: ['-DHAVE_LIBSYSTEMD=0'],
 )
 
 executable('mctp-req',
@@ -92,6 +94,7 @@ if libsystemd.found()
         dependencies: [libsystemd, toml_dep],
         install: true,
         install_dir: get_option('sbindir'),
+        c_args: ['-DHAVE_LIBSYSTEMD=1'],
     )
 
     mctpd_test = executable('test-mctpd',
@@ -100,6 +103,7 @@ if libsystemd.found()
         ] + test_ops_sources + netlink_sources + util_sources,
         include_directories:  include_directories('src'),
         dependencies: [libsystemd, toml_dep],
+        c_args: ['-DHAVE_LIBSYSTEMD=1'],
     )
 endif
 

--- a/src/mctp-ops.c
+++ b/src/mctp-ops.c
@@ -9,6 +9,9 @@
 
 #include <unistd.h>
 #include <linux/netlink.h>
+#if HAVE_LIBSYSTEMD
+#include <systemd/sd-event.h>
+#endif
 #include <err.h>
 
 #include "mctp.h"
@@ -74,6 +77,12 @@ const struct mctp_ops mctp_ops = {
 		.recvfrom = mctp_op_recvfrom,
 		.close = mctp_op_close,
 	},
+#if HAVE_LIBSYSTEMD
+	.sd_event = {
+		.add_time_relative = sd_event_add_time_relative,
+		.source_set_time_relative = sd_event_source_set_time_relative,
+	},
+#endif
 	.bug_warn = mctp_bug_warn,
 };
 

--- a/src/mctp-ops.h
+++ b/src/mctp-ops.h
@@ -9,6 +9,9 @@
 
 #include <sys/socket.h>
 #include <stdarg.h>
+#if HAVE_LIBSYSTEMD
+#include <systemd/sd-event.h>
+#endif
 
 #define _GNU_SOURCE
 
@@ -24,9 +27,19 @@ struct socket_ops {
 	int (*close)(int sd);
 };
 
+#if HAVE_LIBSYSTEMD
+struct sd_event_ops {
+	typeof(sd_event_add_time_relative) *add_time_relative;
+	typeof(sd_event_source_set_time_relative) *source_set_time_relative;
+};
+#endif
+
 struct mctp_ops {
 	struct socket_ops mctp;
 	struct socket_ops nl;
+#if HAVE_LIBSYSTEMD
+	struct sd_event_ops sd_event;
+#endif
 	void (*bug_warn)(const char *fmt, va_list args);
 };
 

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -497,8 +497,9 @@ static int wait_fd_timeout(int fd, short events, uint64_t timeout_usec)
 	if (rc < 0)
 		goto out;
 
-	rc = sd_event_add_time_relative(ev, NULL, CLOCK_MONOTONIC, timeout_usec,
-					0, cb_exit_loop_timeout, NULL);
+	rc = mctp_ops.sd_event.add_time_relative(ev, NULL, CLOCK_MONOTONIC,
+						 timeout_usec, 0,
+						 cb_exit_loop_timeout, NULL);
 	if (rc < 0)
 		goto out;
 
@@ -3239,8 +3240,8 @@ static int peer_endpoint_recover(sd_event_source *s, uint64_t usec,
 
 reschedule:
 	if (peer->recovery.npolls > 0) {
-		rc = sd_event_source_set_time_relative(peer->recovery.source,
-						       peer->recovery.delay);
+		rc = mctp_ops.sd_event.source_set_time_relative(
+			peer->recovery.source, peer->recovery.delay);
 		if (rc >= 0) {
 			rc = sd_event_source_set_enabled(peer->recovery.source,
 							 SD_EVENT_ONESHOT);
@@ -3275,7 +3276,7 @@ static int method_endpoint_recover(sd_bus_message *call, void *data,
 		peer->recovery.npolls = MCTP_I2C_TSYM_MN1_MIN + 1;
 		peer->recovery.delay =
 			(MCTP_I2C_TSYM_TRECLAIM_MIN_US / 2) - ctx->mctp_timeout;
-		rc = sd_event_add_time_relative(
+		rc = mctp_ops.sd_event.add_time_relative(
 			ctx->event, &peer->recovery.source, CLOCK_MONOTONIC, 0,
 			ctx->mctp_timeout, peer_endpoint_recover, peer);
 		if (rc < 0) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 import asyncdbus
+import trio.testing
 
 import mctpenv
 
@@ -35,3 +36,10 @@ async def mctpd(nursery, dbus, sysnet, config):
 @pytest.fixture
 async def mctp(nursery, sysnet):
     return mctpenv.MctpWrapper(nursery, sysnet)
+
+@pytest.fixture
+def autojump_clock():
+    """
+    Custom autojump clock with a reasonable threshold for non-time I/O waits
+    """
+    return trio.testing.MockClock(autojump_threshold=0.01)

--- a/tests/test-proto.h
+++ b/tests/test-proto.h
@@ -9,6 +9,7 @@ enum {
 	CONTROL_OP_INIT,
 	CONTROL_OP_SOCKET_MCTP,
 	CONTROL_OP_SOCKET_NL,
+	CONTROL_OP_TIMER,
 };
 
 struct control_msg_req {

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -50,6 +50,7 @@ async def _introspect_path_recursive(dbus, path, node_set):
 
     return dups
 
+
 """ Test that the dbus object tree is sensible: we can introspect all
 objects, and that there are no duplicates
 """
@@ -187,7 +188,7 @@ async def test_recover_endpoint_present(dbus, mctpd):
     # to transition 'Connectivity' to 'Available', which is a test failure.
     assert not expected.cancelled_caught
 
-async def test_recover_endpoint_removed(dbus, mctpd):
+async def test_recover_endpoint_removed(dbus, mctpd, autojump_clock):
     iface = mctpd.system.interfaces[0]
     dev = mctpd.network.endpoints[0]
     mctp = await dbus.get_proxy_object(MCTPD_C, MCTPD_MCTP_P)
@@ -224,7 +225,7 @@ async def test_recover_endpoint_removed(dbus, mctpd):
 
     assert not expected.cancelled_caught
 
-async def test_recover_endpoint_reset(dbus, mctpd):
+async def test_recover_endpoint_reset(dbus, mctpd, autojump_clock):
     iface = mctpd.system.interfaces[0]
     dev = mctpd.network.endpoints[0]
     mctp = await dbus.get_proxy_object(MCTPD_C, MCTPD_MCTP_P)
@@ -260,7 +261,7 @@ async def test_recover_endpoint_reset(dbus, mctpd):
 
     assert not expected.cancelled_caught
 
-async def test_recover_endpoint_exchange(dbus, mctpd):
+async def test_recover_endpoint_exchange(dbus, mctpd, autojump_clock):
     iface = mctpd.system.interfaces[0]
     dev = mctpd.network.endpoints[0]
     mctp = await dbus.get_proxy_object(MCTPD_C, MCTPD_MCTP_P)
@@ -628,7 +629,7 @@ async def test_network_local_eids_none(dbus, mctpd):
 
     assert eids == []
 
-async def test_concurrent_recovery_setup(dbus, mctpd):
+async def test_concurrent_recovery_setup(dbus, mctpd, autojump_clock):
     iface = mctpd.system.interfaces[0]
     mctp_i = await mctpd_mctp_iface_obj(dbus, iface)
 


### PR DESCRIPTION
In tests, replace all sd_event timer usages with trio.testing.MockClock
backed I/O sources.

Because we still have real timeouts (D-Bus call to mctpd subprocess,
mctpd SO_RCVTIMEO wait, ...), autojump_threshold (how much to wait
before skipping Trio timeouts) is set to a reasonable value to take that
into account.