### PR TITLE
github: always upload test log

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,7 @@ jobs:
         run: meson test -C build --verbose
 
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: default-meson-testlog
           path: build/meson-logs/testlog.txt
@@ -60,6 +61,7 @@ jobs:
         run: meson test -C build --verbose
 
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: no-libsystemd-meson-testlog
           path: build/meson-logs/testlog.txt


### PR DESCRIPTION
When previous CI steps fail, the test log upload step will be skipped. Change the condition to always run.

Fixes: e9988db83167 (github: upload test log as an artifact)