### PR TITLE
mctpd: Add VendorDefinedMessageTypes property

### DIFF
--- a/src/mctp-control-spec.h
+++ b/src/mctp-control-spec.h
@@ -114,12 +114,18 @@ struct mctp_ctrl_resp_get_vdm_support {
 	uint8_t completion_code;
 	uint8_t vendor_id_set_selector;
 	uint8_t vendor_id_format;
-	union {
-		uint16_t vendor_id_data_pcie;
-		uint32_t vendor_id_data_iana;
-	};
 	/* following bytes are dependent on vendor id format
 	 * and shall be interpreted by appropriate binding handler */
+} __attribute__((__packed__));
+
+struct mctp_vdm_pcie_data {
+	uint16_t vendor_id;
+	uint16_t cmd_set;
+} __attribute__((__packed__));
+
+struct mctp_vdm_iana_data {
+	uint32_t enterprise_number;
+	uint16_t cmd_set;
 } __attribute__((__packed__));
 
 struct mctp_pci_ctrl_resp_get_vdm_support {


### PR DESCRIPTION
Implement Get VDM Support (0x06) control command to query vendor defined message capabilities from peers. Expose via D-Bus property a(yvu) containing format, vendor_id (PCIe 16-bit or IANA 32-bit), and command set. Includes positive test for both formats and negative tests for invalid responses (wrong lengths, invalid format, unsupported command).