### PR TITLE
mctpd: add AssignBridgeStatic method

### DIFF
--- a/docs/mctpd.md
+++ b/docs/mctpd.md
@@ -203,6 +203,37 @@ This call will fail if the endpoint already has an EID, and that EID is
 different from `static-EID`, or if `static-EID` is already assigned to another
 endpoint.
 
+#### `.AssignBridgeStatic`: `ayyyy` → `yyisb`
+
+This method performs a static assignment with bridge EID pool allocation.
+
+Similar to AssignEndpointStatic, but takes an additional pool-start-EID
+and pool-size argument:
+
+```
+AssignBridgeStatic <hwaddr> <static-EID> <pool-start-EID> <pool-size>
+```
+
+`<pool-start-EID>`: The starting EID for the range of EIDs being allocated.
+This EID must be contiguous with the bridge’s own EID, to comply with the
+current MCTP 1.3.x specification. In future releases, this restriction
+may be relaxed.
+If passed as 0, mctpd will automatically choose a pool start EID.
+
+`<pool-size>`: The number of EIDs to be allocated to the bridge's EID pool.
+
+Returns:
+```
+eid        (byte)
+poolstart  (byte)
+net        (integer)
+path       (string)
+new        (bool) - true if a new EID was assigned
+```
+
+Where `eid` is the assigned EID, `poolstart` is the starting EID of the allocated
+bridge EID pool, and the remaining fields are the same as the methods above.
+
 #### `.LearnEndpoint`: `ay` → `yisb`
 
 Like SetupEndpoint but will not assign EIDs, will only query endpoints for a

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -2329,6 +2329,34 @@ static int allocate_eid(struct ctx *ctx, struct net *net,
 	return -1;
 }
 
+/**
+ * Validate EID pool allocation for an MCTP bridge.
+ *
+ * Ensures the pool starts at bridge_eid + 1 and verifies that neither the
+ * bridge EID nor the pool range conflicts with existing peer allocations in
+ * the network.
+ *
+ * @return 0 on success, -1 on failure.
+ */
+static int check_bridge_eid_alloc(struct net *net, mctp_eid_t bridge_eid,
+				  mctp_eid_t pool_start, unsigned int pool_size)
+{
+	mctp_eid_t eid;
+
+	if (pool_start != (bridge_eid + 1))
+		return -1;
+
+	if (net->peers[bridge_eid])
+		return -1;
+
+	for (eid = pool_start; eid < (pool_start + pool_size); eid++) {
+		if (net->peers[eid])
+			return -1;
+	}
+
+	return 0;
+}
+
 static int endpoint_assign_eid(struct ctx *ctx, sd_bus_error *berr,
 			       const dest_phys *dest, struct peer **ret_peer,
 			       mctp_eid_t static_eid, bool assign_bridge)
@@ -2427,6 +2455,100 @@ static int endpoint_assign_eid(struct ctx *ctx, sd_bus_error *berr,
 				berr, SD_BUS_ERROR_FAILED,
 				"Endpoint requested EID %d instead of assigned %d, already used",
 				new_eid, peer->eid);
+		}
+		if (rc < 0) {
+			remove_peer(peer);
+			return rc;
+		}
+	}
+
+	rc = setup_added_peer(peer);
+	if (rc < 0)
+		return rc;
+	*ret_peer = peer;
+
+	return 0;
+}
+
+static int
+endpoint_assign_bridge_static_eid(struct ctx *ctx, sd_bus_error *berr,
+				  const dest_phys *dest, struct peer **ret_peer,
+				  mctp_eid_t static_eid, mctp_eid_t pool_start,
+				  uint8_t pool_size)
+{
+	struct peer *peer = NULL;
+	uint8_t req_pool_size;
+	struct net *n = NULL;
+	uint32_t net;
+	int rc;
+
+	net = mctp_nl_net_byindex(ctx->nl, dest->ifindex);
+	if (!net) {
+		bug_warn("No net known for ifindex %d", dest->ifindex);
+		return -EPROTO;
+	}
+
+	n = lookup_net(ctx, net);
+	if (!n) {
+		bug_warn("Unknown net %d", net);
+		return -EPROTO;
+	}
+
+	rc = check_bridge_eid_alloc(n, static_eid, pool_start, pool_size);
+	if (rc) {
+		warnx("Cannot allocate static EID (+pool %d) on net %d for %s",
+		      pool_size, net, dest_phys_tostr(dest));
+		sd_bus_error_setf(berr, SD_BUS_ERROR_FAILED, "Ran out of EIDs");
+		return -EADDRNOTAVAIL;
+	}
+
+	rc = add_peer(ctx, dest, static_eid, net, &peer, false);
+	if (rc < 0)
+		return rc;
+
+	peer->pool_size = pool_size;
+	if (peer->pool_size)
+		peer->pool_start = pool_start;
+
+	add_peer_route(peer);
+
+	rc = endpoint_send_set_endpoint_id(peer, &static_eid, &req_pool_size);
+	if (rc == -ECONNREFUSED)
+		sd_bus_error_setf(
+			berr, SD_BUS_ERROR_FAILED,
+			"Endpoint returned failure to Set Endpoint ID");
+
+	if (rc < 0) {
+		// we have not yet created the pool route, reset here so that
+		// remove_peer() does not attempt to remove it
+		peer->pool_size = 0;
+		peer->pool_start = 0;
+		remove_peer(peer);
+		return rc;
+	}
+
+	if (req_pool_size > peer->pool_size) {
+		warnx("EID %d: requested pool size (%d) > pool size available (%d), limiting.",
+		      peer->eid, req_pool_size, peer->pool_size);
+	} else {
+		// peer will likely have requested less than the available range
+		peer->pool_size = req_pool_size;
+	}
+
+	if (!peer->pool_size)
+		peer->pool_start = 0;
+
+	if (static_eid != peer->eid) {
+		// avoid allocation for any different EID in response
+		warnx("Mismatch of requested from received EID, resetting the pool");
+		peer->pool_size = 0;
+		peer->pool_start = 0;
+		rc = change_peer_eid(peer, static_eid);
+		if (rc == -EEXIST) {
+			sd_bus_error_setf(
+				berr, SD_BUS_ERROR_FAILED,
+				"Endpoint requested EID %d instead of assigned %d, already used",
+				static_eid, peer->eid);
 		}
 		if (rc < 0) {
 			remove_peer(peer);
@@ -3121,6 +3243,98 @@ static int method_assign_endpoint_static(sd_bus_message *call, void *data,
 
 	return sd_bus_reply_method_return(call, "yisb", peer->eid, peer->net,
 					  peer_path, 1);
+err:
+	set_berr(ctx, rc, berr);
+	return rc;
+}
+
+static int method_assign_bridge_static(sd_bus_message *call, void *data,
+				       sd_bus_error *berr)
+{
+	dest_phys desti, *dest = &desti;
+	const char *peer_path = NULL;
+	struct peer *peer = NULL;
+	struct link *link = data;
+	struct ctx *ctx = link->ctx;
+	uint8_t eid;
+	uint8_t pool_start;
+	uint8_t pool_size;
+	bool new = true;
+	int rc;
+
+	dest->ifindex = link->ifindex;
+	if (dest->ifindex <= 0)
+		return sd_bus_error_setf(berr, SD_BUS_ERROR_INVALID_ARGS,
+					 "Unknown MCTP interface");
+
+	rc = message_read_hwaddr(call, dest);
+	if (rc < 0)
+		goto err;
+
+	rc = sd_bus_message_read(call, "y", &eid);
+	if (rc < 0)
+		goto err;
+
+	rc = sd_bus_message_read(call, "y", &pool_start);
+	if (rc < 0)
+		goto err;
+
+	rc = sd_bus_message_read(call, "y", &pool_size);
+	if (rc < 0)
+		goto err;
+
+	rc = validate_dest_phys(ctx, dest);
+	if (rc < 0)
+		return sd_bus_error_setf(berr, SD_BUS_ERROR_INVALID_ARGS,
+					 "Bad physaddr");
+
+	if (pool_start == 0) {
+		pool_start = eid + 1;
+	} else if (pool_start != (eid + 1)) {
+		return sd_bus_error_setf(berr, SD_BUS_ERROR_INVALID_ARGS,
+					 "Bad pool start EID");
+	}
+
+	peer = find_peer_by_phys(ctx, dest);
+	if (peer) {
+		if (eid && peer->eid == eid && pool_size == peer->pool_size) {
+			new = false;
+			goto out;
+		}
+
+		remove_peer(peer);
+		peer = NULL;
+	} else {
+		uint32_t netid;
+
+		// is the requested EID already in use? if so, reject
+		netid = mctp_nl_net_byindex(ctx->nl, dest->ifindex);
+		peer = find_peer_by_addr(ctx, eid, netid);
+		if (peer) {
+			return sd_bus_error_setf(berr,
+						 SD_BUS_ERROR_INVALID_ARGS,
+						 "Address in use");
+		}
+	}
+
+	rc = endpoint_assign_bridge_static_eid(ctx, berr, dest, &peer, eid,
+					       pool_start, pool_size);
+	if (rc < 0) {
+		goto err;
+	}
+
+	if (peer->pool_size > 0)
+		endpoint_allocate_eids(peer);
+
+out:
+	peer_path = path_from_peer(peer);
+	if (!peer_path)
+		goto err;
+
+	return sd_bus_reply_method_return(call, "yyisb", peer->eid,
+					  peer->pool_start, peer->net,
+					  peer_path, new);
+
 err:
 	set_berr(ctx, rc, berr);
 	return rc;
@@ -4053,6 +4267,21 @@ static const sd_bus_vtable bus_link_owner_vtable[] = {
 		SD_BUS_PARAM(path)
 		SD_BUS_PARAM(new),
 		method_assign_endpoint_static,
+		0),
+
+	SD_BUS_METHOD_WITH_NAMES("AssignBridgeStatic",
+		"ayyyy",
+		SD_BUS_PARAM(physaddr)
+		SD_BUS_PARAM(eid)
+		SD_BUS_PARAM(poolstart)
+		SD_BUS_PARAM(poolsize),
+		"yyisb",
+		SD_BUS_PARAM(eid)
+		SD_BUS_PARAM(poolstart)
+		SD_BUS_PARAM(net)
+		SD_BUS_PARAM(path)
+		SD_BUS_PARAM(new),
+		method_assign_bridge_static,
 		0),
 
 	SD_BUS_METHOD_WITH_NAMES("LearnEndpoint",

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -431,6 +431,123 @@ async def test_assign_endpoint_static_varies(dbus, mctpd):
     assert str(ex.value) == "Already assigned a different EID"
 
 
+async def test_assign_bridge_static(dbus, mctpd):
+    """Test that AssignBridgeStatic assigns the requested EID and pool to a
+    bridge endpoint, and marks it as new on first call.
+    """
+    iface = mctpd.system.interfaces[0]
+    dev = mctpd.network.endpoints[0]
+    mctp = await mctpd_mctp_iface_obj(dbus, iface)
+    static_eid = 12
+    pool_size = 3
+    pool_start = static_eid + 1
+
+    for _ in range(pool_size):
+        dev.add_bridged_ep(Endpoint(iface, bytes()))
+
+    (eid, pool_start_out, _, _, new) = await mctp.call_assign_bridge_static(
+        dev.lladdr, static_eid, pool_start, pool_size
+    )
+
+    assert eid == static_eid
+    assert pool_start_out == pool_start
+    assert new
+
+
+async def test_assign_bridge_static_zero_start(dbus, mctpd):
+    """Test that AssignBridgeStatic sets pool start EID to bridge-eid+1
+    when pool_start is passed as zero.
+    """
+    iface = mctpd.system.interfaces[0]
+    dev = mctpd.network.endpoints[0]
+    mctp = await mctpd_mctp_iface_obj(dbus, iface)
+    static_eid = 12
+    pool_size = 3
+    pool_start = 0
+    expected_pool_start = static_eid + 1
+
+    for _ in range(pool_size):
+        dev.add_bridged_ep(Endpoint(iface, bytes()))
+
+    (eid, pool_start_out, _, _, new) = await mctp.call_assign_bridge_static(
+        dev.lladdr, static_eid, pool_start, pool_size
+    )
+
+    assert eid == static_eid
+    assert pool_start_out == expected_pool_start
+    assert new
+
+
+async def test_assign_bridge_static_conflict(dbus, mctpd):
+    """Test that AssignBridgeStatic rejects an EID that is already in use by
+    a different endpoint.
+    """
+    iface = mctpd.system.interfaces[0]
+    dev1 = mctpd.network.endpoints[0]
+    mctp = await mctpd_mctp_iface_obj(dbus, iface)
+
+    dev2 = Endpoint(iface, bytes([0x1E]))
+    mctpd.network.add_endpoint(dev2)
+
+    static_eid = 12
+    pool_size = 3
+    pool_start = static_eid + 1
+
+    for _ in range(pool_size):
+        dev2.add_bridged_ep(Endpoint(iface, bytes()))
+
+    (eid, _, _, new) = await mctp.call_assign_endpoint_static(
+        dev1.lladdr, static_eid
+    )
+    assert eid == static_eid
+    assert new
+
+    # try to assign dev2 the same EID — must fail
+    with pytest.raises(asyncdbus.errors.DBusError) as ex:
+        await mctp.call_assign_bridge_static(
+            dev2.lladdr, static_eid, pool_start, pool_size
+        )
+
+    assert str(ex.value) == "Address in use"
+
+
+async def test_assign_bridge_static_pool_conflict(dbus, mctpd):
+    """Test that AssignBridgeStatic rejects assigning a pool range that
+    conflicts with an existing endpoint's EID, even if the bridge EID itself
+    does not conflict.
+    """
+    iface = mctpd.system.interfaces[0]
+    dev1 = mctpd.network.endpoints[0]
+    mctp = await mctpd_mctp_iface_obj(dbus, iface)
+
+    dev2 = Endpoint(iface, bytes([0x1E]))
+    mctpd.network.add_endpoint(dev2)
+
+    # dev1 is a single endpoint assigned EID 13
+    dev1_eid = 13
+    (eid1, _, _, new1) = await mctp.call_assign_endpoint_static(
+        dev1.lladdr, dev1_eid
+    )
+    assert eid1 == dev1_eid
+    assert new1
+
+    # dev2 is a bridge endpoint with EID 11, pool size 3 (pool start 12, range 12-14)
+    dev2_eid = 11
+    pool_size = 3
+    pool_start = dev2_eid + 1
+
+    for _ in range(pool_size):
+        dev2.add_bridged_ep(Endpoint(iface, bytes()))
+
+    # try to assign dev2 — must fail due to pool conflict at EID 13
+    with pytest.raises(asyncdbus.errors.DBusError) as ex:
+        await mctp.call_assign_bridge_static(
+            dev2.lladdr, dev2_eid, pool_start, pool_size
+        )
+
+    assert str(ex.value) == "Ran out of EIDs"
+
+
 async def test_get_endpoint_id(dbus, mctpd, routed_ep):
     """Test that the mctpd control protocol responder support has support for a
     basic Get Endpoint ID command


### PR DESCRIPTION
Add AssignBridgeStatic method to assign static EID with bridge pool allocation.

Tested:
```
root@bmc:~# busctl call au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/interfaces/mcu1u2u1u4u1 au.com.codeconstruct.MCTP.BusOwner1 AssignBridgeStatic ayyyy 0 30 5 31
yisb 30 1 "/au/com/codeconstruct/mctp1/networks/1/endpoints/30" true
root@bmc:~# busctl introspect au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/networks/1/endpoints/30
NAME                                TYPE      SIGNATURE RESULT/VALUE                           FLAGS
au.com.codeconstruct.MCTP.Bridge1   interface -         -                                      -
.PoolEnd                            property  y         35                                     const
.PoolStart                          property  y         31                                     const
au.com.codeconstruct.MCTP.Endpoint1 interface -         -                                      -
.Recover                            method    -         -                                      -
.Remove                             method    -         -                                      -
.SetMTU                             method    u         -                                      -
.Connectivity                       property  s         "Available"                            emits-change
org.freedesktop.DBus.Introspectable interface -         -                                      -
.Introspect                         method    -         s                                      -
org.freedesktop.DBus.Peer           interface -         -                                      -
.GetMachineId                       method    -         s                                      -
.Ping                               method    -         -                                      -
org.freedesktop.DBus.Properties     interface -         -                                      -
.Get                                method    ss        v                                      -
.GetAll                             method    s         a{sv}                                  -
.Set                                method    ssv       -                                      -
.PropertiesChanged                  signal    sa{sv}as  -                                      -
xyz.openbmc_project.Common.UUID     interface -         -                                      -
.UUID                               property  s         "8b7e3d86-5fa5-298c-a9d6-a2d5d4baa6fa" const
xyz.openbmc_project.MCTP.Endpoint   interface -         -                                      -
.EID                                property  y         30                                     const
.NetworkId                          property  u         1                                      const
.SupportedMessageTypes              property  ay        4 1 5 126 127                          const
.VendorDefinedMessageTypes          property  a(yvq)    0                                      const
```

Signed-off-by: Potin Lai <potin.lai@quantatw.com>