### PR TITLE
mctpd: fix zeroed ctrl_hdr in endpoint discovery

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -1233,6 +1233,9 @@ handle_control_endpoint_discovery(struct ctx *ctx, int sd,
 		return 0;
 	}
 
+	req = (void *)buf;
+	mctp_ctrl_msg_hdr_init_resp(&resp->ctrl_hdr, *req);
+
 	if (link_data->discovered == DISCOVERY_UNSUPPORTED) {
 		resp->completion_code = MCTP_CTRL_CC_ERROR_INVALID_DATA;
 		return reply_message(ctx, sd, resp,
@@ -1243,10 +1246,6 @@ handle_control_endpoint_discovery(struct ctx *ctx, int sd,
 		// if we are already discovered (i.e, assigned an EID), then no reply
 		return 0;
 	}
-
-	req = (void *)buf;
-	resp = (void *)resp;
-	mctp_ctrl_msg_hdr_init_resp(&resp->ctrl_hdr, *req);
 
 	// we need to send using physical addressing, no entry in routing table yet
 	return reply_message_phys(ctx, sd, resp, sizeof(*resp), addr);


### PR DESCRIPTION
In handle_control_endpoint_discovery(), the response header
initialization (mctp_ctrl_msg_hdr_init_resp) was placed after the
DISCOVERY_UNSUPPORTED check. When the interface has discovery
unsupported, the function would call reply_message() with a zeroed
ctrl_hdr, sending a response with no command code and no instance ID

Move the req/resp pointer setup and mctp_ctrl_msg_hdr_init_resp()
call so that response carries a correctly initialized control header.