### PR TITLE
mctpd: Improve sequencing of Set Endpoint ID responses in endpoint mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
    re-use outgoing control protocol instance IDs (IIDs) when we re-send
    commands. More instances of commands now have retry logic too.
 
+3. When running in endpoint mode, `mctpd` will now issue responses to incoming
+   Set Endpoint ID commands before performing enumeration on the (bus-owner)
+   peer.
+
 ## [2.5] - 2026-02-17
 
 ### Added

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -899,6 +899,7 @@ static int handle_control_set_endpoint_id(struct ctx *ctx, int sd,
 
 		rc = add_peer_from_addr(ctx, addr, &peer);
 		if (rc == 0) {
+			add_peer_route(peer);
 			rc = setup_added_peer(peer);
 		}
 		if (rc < 0) {
@@ -2713,6 +2714,8 @@ static int get_endpoint_peer(struct ctx *ctx, sd_bus_error *berr,
 		rc = add_peer(ctx, dest, eid, net, &peer, false);
 		if (rc < 0)
 			return rc;
+
+		add_peer_route(peer);
 	}
 
 	peer->endpoint_type = ep_type;
@@ -3092,6 +3095,7 @@ static int method_setup_endpoint(sd_bus_message *call, void *data,
 		} else if (rc < 0) {
 			goto err;
 		} else {
+			add_peer_route(peer);
 			peer->endpoint_type = ep_type;
 			peer->medium_spec = medium_spec;
 			rc = setup_added_peer(peer);
@@ -3509,11 +3513,6 @@ static int setup_added_peer(struct peer *peer)
 	// Set minimum MTU by default for compatibility. Clients can increase
 	// this with .SetMTU as needed
 	peer->mtu = mctp_nl_min_mtu_byindex(peer->ctx->nl, peer->phys.ifindex);
-
-	// add route before querying for non-bridged endpoints.
-	// bridged endpoints will use the bridge's pool range route.
-	if (!is_eid_in_bridge_pool(n, peer->ctx, peer->eid))
-		add_peer_route(peer);
 
 	rc = query_peer_properties(peer);
 	if (rc < 0)

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -894,28 +894,44 @@ static int handle_control_set_endpoint_id(struct ctx *ctx, int sd,
 		if (rc < 0) {
 			warnx("ERR: cannot add local eid %d to ifindex %d",
 			      req->eid, addr->smctp_ifindex);
+			resp_len = sizeof(struct mctp_ctrl_resp);
 			resp->completion_code = MCTP_CTRL_CC_ERROR_NOT_READY;
+			reply_message(ctx, sd, resp, resp_len, addr);
+			return rc;
 		}
 
 		rc = add_peer_from_addr(ctx, addr, &peer);
-		if (rc == 0) {
-			add_peer_route(peer);
-			rc = setup_added_peer(peer);
-		}
-		if (rc < 0) {
-			warnx("ERR: cannot add bus owner to object lists");
+		if (rc) {
+			errno = -rc;
+			warn("failed setting up bus owner, rejecting Set EID");
+			resp->completion_code = MCTP_CTRL_CC_ERROR;
+			resp_len = sizeof(struct mctp_ctrl_resp);
+			reply_message(ctx, sd, resp, resp_len, addr);
+			return rc;
 		}
 
-		if (link_data->discovered != DISCOVERY_UNSUPPORTED) {
+		add_peer_route(peer);
+
+		if (link_data->discovered != DISCOVERY_UNSUPPORTED)
 			link_data->discovered = DISCOVERY_DISCOVERED;
-		}
+
 		resp->status =
 			SET_MCTP_EID_ASSIGNMENT_STATUS(MCTP_SET_EID_ACCEPTED) |
 			SET_MCTP_EID_ALLOCATION_STATUS(MCTP_SET_EID_POOL_NONE);
 		resp->eid_set = req->eid;
 		resp->eid_pool_size = 0;
-		fprintf(stderr, "Accepted set eid %d\n", req->eid);
-		return reply_message(ctx, sd, resp, resp_len, addr);
+		rc = reply_message(ctx, sd, resp, resp_len, addr);
+		if (rc) {
+			errno = -rc;
+			warn("failed responding to set eid request");
+			return rc;
+		}
+
+		rc = setup_added_peer(peer);
+		if (rc < 0)
+			warnx("ERR: cannot add bus owner to object lists");
+
+		return 0;
 
 	case MCTP_SET_EID_DISCOVERED:
 		if (link_data->discovered == DISCOVERY_UNSUPPORTED) {

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -127,7 +127,7 @@ async def test_setup_endpoint(dbus, mctpd):
     assert neigh.eid == ep.eid
 
     # we should have a route for the new endpoint too
-    assert len(mctpd.system.routes) == 2
+    assert len(mctpd.system.routes) == 1
 
 
 async def test_setup_endpoint_conflict(dbus, mctpd):
@@ -356,7 +356,7 @@ async def test_assign_endpoint_static(dbus, mctpd):
     neigh = mctpd.system.neighbours[0]
     assert neigh.lladdr == dev.lladdr
     assert neigh.eid == static_eid
-    assert len(mctpd.system.routes) == 2
+    assert len(mctpd.system.routes) == 1
 
 
 async def test_assign_endpoint_static_allocated(dbus, mctpd):


### PR DESCRIPTION
When running in endpoint mode, mctpd's Set Endpoint ID command handler will trigger an enumeration of the peer (ie, the bus owner that issued the Set Endpoint ID command).

Currently, that enumeration occurs before we send the Set Endpoint ID response, which is a little unexpected: at that point, the bus owner has not received any indication that the command completed successfully. Also, the wait on the set of peer-enumeration commands may delay the Set Endpoint ID response beyond a command timeout.

So, respond to the Set Endpoint ID command first, then perform peer enumeration. This requires a minor rework to the `setup_endpoint_peer()` process, as we will need to establish routes beforehand.