### PR TITLE
mctpd: fix mctp_ctrl_validate_response size check

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -1675,7 +1675,7 @@ static int mctp_ctrl_validate_response(struct mctp_ctrl_cmd *cmd,
 {
 	struct mctp_ctrl_resp *rsp;
 
-	if (exp_size <= sizeof(*rsp)) {
+	if (exp_size < sizeof(*rsp)) {
 		warnx("invalid expected response size!");
 		return -EINVAL;
 	}


### PR DESCRIPTION
fix mctp_ctrl_validate_response to use strict less-than when comparing exp_size against sizeof(struct mctp_ctrl_resp). The previous <= incorrectly rejected responses whose complete structure is exactly the base response size, such as Discovery Notify.