### PR TITLE
mctp-client: add cci message type code

### DIFF
--- a/src/mctp-client.c
+++ b/src/mctp-client.c
@@ -67,6 +67,12 @@ static struct type_lookup_t {
 			"secured messages using spdm over mctp per DSP0276",
 	},
 	{
+		.name = "cxl-cci",
+		.type = 8,
+		.description =
+			"CXL type 3 device component command interface over mctp per DSP0281",
+	},
+	{
 		.name = "pci",
 		.type = 0x7e,
 		.description = "vdm using a pci based vendor id per DSP0236",


### PR DESCRIPTION
According to Specification DSP0239 1.12.0
Add type code 8 for use with the CXL Type 3 Device Component Command Interface over MCTP.

Testing
---
cci commands
```
mctp-client net 1 eid 10 type cci data 00 00 00 00 03 00 00 00 00 00 cd ab
01 00 00 00 03 08 00 00 00 00 00 00 2B 01 AD 9C A4 8A D2 16
```