### PR TITLE
Fix zero MTU on added peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 1. `mctp-client` binary now handles the `cxl-cci` MCTP message type
 
+### Fixes
+
+1. In v2.6. we lost the peer initial MTU sematics, which gave us a safe minimum
+   MTU on peer routes when peers were added. This is now fixed - peer routes
+   will have an MTU set to the link-reported minimum, as introduced in v2.1.
+
 ## [2.6] - 2026-07-21
 
 ### Added

--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -2048,6 +2048,10 @@ static int add_peer(struct ctx *ctx, const dest_phys *dest, mctp_eid_t eid,
 	peer->state = REMOTE;
 	peer->ctx = ctx;
 
+	// Set minimum MTU by default for compatibility. Clients can increase
+	// this with .SetMTU as needed
+	peer->mtu = mctp_nl_min_mtu_byindex(ctx->nl, peer->phys.ifindex);
+
 	// Update network eid map
 	n->peers[eid] = peer;
 
@@ -3531,9 +3535,6 @@ static int setup_added_peer(struct peer *peer)
 		bug_warn("%s Bad net %u", __func__, peer->net);
 		return -EPROTO;
 	}
-	// Set minimum MTU by default for compatibility. Clients can increase
-	// this with .SetMTU as needed
-	peer->mtu = mctp_nl_min_mtu_byindex(peer->ctx->nl, peer->phys.ifindex);
 
 	rc = query_peer_properties(peer);
 	if (rc < 0)

--- a/tests/mctpenv/__init__.py
+++ b/tests/mctpenv/__init__.py
@@ -1227,7 +1227,10 @@ class NLSocket(BaseSocket):
         gw = msg.get_attr('RTA_GATEWAY')
         start_eid = msg.get_attr('RTA_DST')
         extent_eid = msg['dst_len']
-        # todo: RTAX metrics: MTU
+        mtu = 0
+        metrics = msg.get_attr('RTA_METRICS')
+        if metrics:
+            mtu = metrics.get_attr('RTAX_MTU', default=0)
 
         if ifindex:
             iface = self.system.find_interface_by_ifindex(ifindex)
@@ -1236,7 +1239,7 @@ class NLSocket(BaseSocket):
             gw = (gw['net'], gw['eid'])
             iface = None
 
-        return System.Route(start_eid, extent_eid, iface=iface, gw=gw)
+        return System.Route(start_eid, extent_eid, iface=iface, gw=gw, mtu=mtu)
 
     async def _handle_getroute(self, msg):
         dump = bool(msg['header']['flags'] & netlink.NLM_F_DUMP)

--- a/tests/test_mctpd.py
+++ b/tests/test_mctpd.py
@@ -216,6 +216,22 @@ async def test_setup_endpoint_no_get_uuid(dbus, mctpd):
     assert eid == ep.eid
 
 
+async def test_setup_endpoint_mtu(dbus, mctpd):
+    """Newly-added endpoints should start with a minimum MTU"""
+    iface = mctpd.system.interfaces[0]
+    ep = mctpd.network.endpoints[0]
+
+    # ensure we can distinguish a correct min mtu from a no-mtu case
+    assert iface.min_mtu != 0
+
+    mctp = await mctpd_mctp_iface_obj(dbus, iface)
+    (eid, net, path, new) = await mctp.call_setup_endpoint(ep.lladdr)
+
+    assert len(mctpd.system.routes) == 1
+    route = mctpd.system.routes[0]
+    assert route.mtu == iface.min_mtu
+
+
 async def test_remove_endpoint(dbus, mctpd):
     """Test neighbour removal"""
     iface = mctpd.system.interfaces[0]


### PR DESCRIPTION
v2.6 introduces a regression where peers are added with a zero MTU, rather than the interface-defined minimum, as we were adding the peer routes before setting `peer->mtu`.

Move the default-MTU initialisation to the peer constructor instead.