### PR TITLE
mctpd: Remove downstream peers when bridge node is removed

### DIFF
--- a/src/mctpd.c
+++ b/src/mctpd.c
@@ -2103,15 +2103,15 @@ static int remove_bridged_peers(struct peer *bridge)
 	n = lookup_net(bridge->ctx, bridge->net);
 	pool_start = bridge->pool_start;
 
-	if (!sources)
-		return 0;
+	if (!n)
+		return -EPROTO;
 
 	for (ep = pool_start; ep <= pool_end; ep++) {
 		// stop endpoint polling before removing peer
 		// else next trigger will create peer again.
 		int idx = ep - pool_start;
 
-		if (sources[idx]) {
+		if (sources && sources[idx]) {
 			pctx = sd_event_source_get_userdata(sources[idx]);
 			rc = sd_event_source_set_enabled(sources[idx],
 							 SD_EVENT_OFF);


### PR DESCRIPTION
Currently, remove_bridged_peers() checks 'if (!sources)' and returns
early if bridge_ep_poll.sources is NULL. The sources array is only
allocated when periodic bridge endpoint polling is enabled.

However, downstream endpoints within the allocated bridge pool range
can still be discovered and added to the network via the LearnEndpoint
D-Bus method (or static assignment) even when periodic polling is not
active.

When a bridge node is removed, the early return in
remove_bridged_peers() causes the pool iteration loop to be skipped if
polling was inactive. As a result, downstream node EID objects remain
registered in mctpd and published on D-Bus as orphaned endpoints.


Fix this by:
1. Replacing the early 'if (!sources) return 0;' check with network
   validation ('if (!n) return -EPROTO;').
2. Guarding polling timer teardown with 'if (sources && sources[idx])'.

This ensures remove_bridged_peers() always iterates across the bridge's
allocated pool range [pool_start, pool_end] and invokes remove_peer() on
all existing downstream node EID objects when the parent bridge node is
removed.