### PR TITLE
mctpd: grant CAP_NET_RAW

### DIFF
--- a/conf/mctpd.service
+++ b/conf/mctpd.service
@@ -9,7 +9,7 @@ Type=dbus
 BusName=au.com.codeconstruct.MCTP1
 ExecStart=/usr/sbin/mctpd
 User=mctpd
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
 
 [Install]
 WantedBy=mctp.target


### PR DESCRIPTION
The kernel MCTP socket implementation requires CAP_NET_RAW to send MCTP control messages when mctpd runs as an unprivileged user.